### PR TITLE
fix issue with float not saving enough info for timestamps

### DIFF
--- a/include/autoware/mtr/node.hpp
+++ b/include/autoware/mtr/node.hpp
@@ -168,7 +168,7 @@ private:
   PolylineTypeMap polyline_type_map_;
   std::shared_ptr<PolylineData> polyline_ptr_;
   std::vector<std::pair<float, AgentState>> ego_states_;
-  std::vector<float> timestamps_;
+  std::vector<double> timestamps_;
 };  // class MTRNode
 }  // namespace autoware::mtr
 #endif  // AUTOWARE__MTR__NODE_HPP_

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -26,7 +26,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <vector>
 
 namespace autoware::mtr
 {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <vector>
 
 namespace autoware::mtr
 {
@@ -597,9 +598,10 @@ std::vector<size_t> MTRNode::extractTargetAgent(const std::vector<AgentHistory> 
 
 std::vector<float> MTRNode::getRelativeTimestamps() const
 {
-  auto output = timestamps_;
+  std::vector<float> output;
+  output.reserve(timestamps_.size());
   for (auto & t : output) {
-    t -= timestamps_.at(0);
+    output.push_back(t - timestamps_.at(0));
   }
   return output;
 }


### PR DESCRIPTION
Currently, the timestamps_ vector uses float, this is a problem because float does not have enough space to store the timestamp info contained on the header of tracked objects (making the relative time calculation wrong). This PR fixes the issue