### PR TITLE
feat: add fixed queue

### DIFF
--- a/include/autoware/mtr/fixed_queue.hpp
+++ b/include/autoware/mtr/fixed_queue.hpp
@@ -1,0 +1,70 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MTR__FIXED_QUEUE_HPP_
+#define AUTOWARE__MTR__FIXED_QUEUE_HPP_
+
+#include <cstddef>
+#include <deque>
+
+namespace autoware::mtr
+{
+
+template <typename T>
+class FixedQueue
+{
+public:
+  using size_type = typename std::deque<T>::size_type;
+  using iterator = typename std::deque<T>::iterator;
+  using const_iterator = typename std::deque<T>::const_iterator;
+
+  explicit FixedQueue(size_t size) { queue_.resize(size); }
+
+  void push_back(const T && t) noexcept
+  {
+    queue_.pop_front();
+    queue_.push_back(t);
+  }
+
+  void push_back(const T & t) noexcept
+  {
+    queue_.pop_front();
+    queue_.push_back(t);
+  }
+
+  void push_front(const T && t) noexcept
+  {
+    queue_.pop_back();
+    queue_.push_front(t);
+  }
+
+  void push_front(const T & t) noexcept
+  {
+    queue_.pop_back();
+    queue_.push_front(t);
+  }
+
+  iterator begin() noexcept { return queue_.begin(); }
+  const_iterator begin() const noexcept { return queue_.begin(); }
+
+  iterator end() noexcept { return queue_.end(); }
+  const_iterator end() const noexcept { return queue_.end(); }
+
+  size_type size() const noexcept { return queue_.size(); }
+
+private:
+  std::deque<T> queue_;
+};
+}  // namespace autoware::mtr
+#endif  // AUTOWARE__MTR__FIXED_QUEUE_HPP_

--- a/include/autoware/mtr/node.hpp
+++ b/include/autoware/mtr/node.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__MTR__NODE_HPP_
 
 #include "autoware/mtr/agent.hpp"
+#include "autoware/mtr/fixed_queue.hpp"
 #include "autoware/mtr/polyline.hpp"
 #include "autoware/mtr/trajectory.hpp"
 #include "autoware/mtr/trt_mtr.hpp"
@@ -167,8 +168,9 @@ private:
   std::unique_ptr<TrtMTR> model_ptr_;
   PolylineTypeMap polyline_type_map_;
   std::shared_ptr<PolylineData> polyline_ptr_;
-  std::vector<std::pair<float, AgentState>> ego_states_;
-  std::vector<double> timestamps_;
+
+  std::unique_ptr<FixedQueue<std::pair<float, AgentState>>> ego_states_;
+  std::unique_ptr<FixedQueue<double>> timestamps_;
 };  // class MTRNode
 }  // namespace autoware::mtr
 #endif  // AUTOWARE__MTR__NODE_HPP_


### PR DESCRIPTION
## What

This PR introduces `FixedQueue` class to store data in a fixed size queue.
This feature allows us to remove redundant deletion such as:

```cpp
// === Before ===
std::vector<double> timestamps_;

const auto current_time = static_cast<float>(rclcpp::Time(object_msg->header.stamp).seconds());
timestamps_.emplace_back(current_time);
if (timestamps_.size() < config_ptr_->num_past) {
  RCLCPP_WARN(get_logger(), "Not enough timestamp");
  return;  // Not enough timestamps
}
if (config_ptr_->num_past < timestamps_.size()) {
  timestamps_.erase(timestamps_.begin(), timestamps_.begin() + 1);
}

// ==== After ===
FixedQueue<double> timestamps_(11); // Fixing size with the number of history length.

const auto current_time = rclcpp::Time(object_msg->header.stamp).seconds();
timestamps_->push_back(current_time);
```

Also, this PR fixes computing relative timestamps:
```shell
# === Before ===
Relative timestamps ()
Relative timestamps ()

# ==== After ===
Relative timestamps: (0 0.100001 0.210008 0.310019 0.420185 0.510029 0.610035 0.720144 0.810001 0.900008 1.01002 )
Relative timestamps: (0 0.110007 0.210018 0.320184 0.410028 0.510035 0.620143 0.71 0.800007 0.910015 1.00002 )
```

It looks OK differences of timestamps are about 0.1 [s] (=100[ms]).
As an assumption MTR expects timestamps are stamped at 10Hz.