### PR TITLE
cpp implementation of agent centric history calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   src/trt_mtr.cpp
   src/conversions/lanelet.cpp
   src/intention_point.cpp
+  src/conversions/history.cpp
 )
 target_link_libraries(${PROJECT_NAME}_lib
   ${TRT_PLUGINS}

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -24,16 +24,31 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
-
 namespace autoware::mtr
 {
 constexpr size_t AgentStateDim = 12;
 
 enum AgentLabel { VEHICLE = 0, PEDESTRIAN = 1, CYCLIST = 2 };
+
+enum AgentDimLabels {
+  X = 0,
+  Y = 1,
+  Z = 2,
+  L = 3,
+  W = 4,
+  H = 5,
+  YAW = 6,
+  VX = 7,
+  VY = 8,
+  AX = 9,
+  AY = 10,
+  VALIDITY = 11
+};
 
 /**
  * @brief A class to represent a single state of an agent.
@@ -230,6 +245,15 @@ struct AgentHistory
   // Get the latest agent state at `T`.
   const AgentState & get_latest_state() const { return *queue_.end(); }
 
+  // Get the latest agent state at `T`.
+  std::optional<AgentState> get_latest_valid_state() const
+  {
+    auto latest_valid_state = std::find_if(
+      queue_.rbegin(), queue_.rend(), [](const auto & state) { return state.is_valid(); });
+    return (latest_valid_state != queue_.rend()) ? std::make_optional(*latest_valid_state)
+                                                 : std::nullopt;
+  }
+
 private:
   FixedQueue<AgentState> queue_;
   const std::string object_id_;
@@ -352,7 +376,7 @@ private:
 };
 
 // Get label names from label indices.
-std::vector<std::string> getLabelNames(const std::vector<size_t> & label_index)
+inline std::vector<std::string> getLabelNames(const std::vector<size_t> & label_index)
 {
   std::vector<std::string> label_names;
   label_names.reserve(label_index.size());

--- a/include/autoware/mtr/conversions/history.hpp
+++ b/include/autoware/mtr/conversions/history.hpp
@@ -1,0 +1,62 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MTR__CONVERSIONS__HISTORY_HPP_
+#define AUTOWARE__MTR__CONVERSIONS__HISTORY_HPP_
+
+#include "autoware/mtr/agent.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::mtr
+{
+
+/**
+ * @brief Transform a 2D point with a reference point and rotation
+ *
+ * @param history history to modify.
+ * @param reference_state reference state used as reference frame.
+ * @return  vector of histories, each in the reference frame of the last state.
+ */
+[[nodiscard]] std::pair<float, float> transform2D(
+  const std::pair<float, float> input_xy, const std::pair<float, float> reference_xy,
+  const std::pair<float, float> rotation_cos_sin);
+
+/**
+ * @brief Get histories with agent states in the reference frame of the last state
+ *
+ * @param history history to modify.
+ * @param reference_state reference state used as reference frame.
+ * @return  vector of histories, each in the reference frame of the last state.
+ */
+[[nodiscard]] AgentHistory getAgentCentricHistory(
+  const AgentHistory & history, const AgentState & reference_state);
+
+/**
+ * @brief Get histories with agent states in the reference frame of the last state
+ *
+ * @param histories vector of histories to modify.
+ * @return  vector of histories, each in the reference frame of the last state.
+ */
+[[nodiscard]] std::vector<AgentHistory> getAgentCentricHistories(
+  const std::vector<AgentHistory> & histories);
+
+}  // namespace autoware::mtr
+
+#endif  // AUTOWARE__MTR__CONVERSIONS__HISTORY_HPP_

--- a/include/autoware/mtr/fixed_queue.hpp
+++ b/include/autoware/mtr/fixed_queue.hpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <deque>
+#include <iterator>
 
 namespace autoware::mtr
 {
@@ -27,7 +28,9 @@ class FixedQueue
 public:
   using size_type = typename std::deque<T>::size_type;
   using iterator = typename std::deque<T>::iterator;
+  using riterator = typename std::reverse_iterator<iterator>;
   using const_iterator = typename std::deque<T>::const_iterator;
+  using rconst_iterator = typename std::reverse_iterator<const_iterator>;
 
   explicit FixedQueue(size_t size) { queue_.resize(size); }
 
@@ -60,6 +63,12 @@ public:
 
   iterator end() noexcept { return queue_.end(); }
   const_iterator end() const noexcept { return queue_.end(); }
+
+  riterator rbegin() noexcept { return queue_.rbegin(); }
+  rconst_iterator rbegin() const noexcept { return queue_.rbegin(); }
+
+  riterator rend() noexcept { return queue_.rend(); }
+  rconst_iterator rend() const noexcept { return queue_.rend(); }
 
   size_type size() const noexcept { return queue_.size(); }
 

--- a/src/conversions/history.cpp
+++ b/src/conversions/history.cpp
@@ -1,0 +1,108 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/mtr/conversions/history.hpp"
+
+namespace autoware::mtr
+{
+using adl = autoware::mtr::AgentDimLabels;
+
+/**
+ * @brief Transform a 2D point with a reference point and rotation
+ *
+ * @param history history to modify.
+ * @param reference_state reference state used as reference frame.
+ * @return  vector of histories, each in the reference frame of the last state.
+ */
+[[nodiscard]] inline std::pair<float, float> transform2D(
+  const std::pair<float, float> input_xy, const std::pair<float, float> reference_xy,
+  const std::pair<float, float> rotation_cos_sin)
+{
+  auto [x, y] = input_xy;
+  auto [ref_x, ref_y] = reference_xy;
+  auto [cos, sin] = rotation_cos_sin;
+  x -= ref_x;
+  y -= ref_y;
+  return {x * cos - y * sin, x * sin + y * cos};
+}
+
+/**
+ * @brief Get histories with agent states in the reference frame of the last state
+ *
+ * @param history history to modify.
+ * @param reference_state reference state used as reference frame.
+ * @return  vector of histories, each in the reference frame of the last state.
+ */
+[[nodiscard]] inline AgentHistory getAgentCentricHistory(
+  const AgentHistory & history, const AgentState & reference_state)
+{
+  const auto latest_valid_state = history.get_latest_valid_state();
+  const auto & reference_state_dim = autoware::mtr::AgentState::dim();
+  const auto & history_state_dim = autoware::mtr::AgentHistory::state_dim();
+
+  if (!latest_valid_state.has_value() || reference_state_dim != history_state_dim) {
+    return history;
+  }
+  AgentHistory agent_centric_history = history;
+  const auto reference_array = reference_state.as_array();
+  auto agent_centric_states_array = agent_centric_history.as_array();
+  const auto ref_x = reference_array.at(adl::X);
+  const auto ref_y = reference_array.at(adl::Y);
+  const auto ref_z = reference_array.at(adl::Z);
+  const auto ref_yaw = reference_array.at(adl::YAW);
+  const auto cos = std::cos(-ref_yaw);
+  const auto sin = std::sin(-ref_yaw);
+
+  const auto & d = reference_state_dim;
+  // Use i as the index for each new state
+  for (size_t i = 0; i < agent_centric_states_array.size(); i += d) {
+    auto & x = agent_centric_states_array.at(i + adl::X);
+    auto & y = agent_centric_states_array.at(i + adl::Y);
+    auto & vx = agent_centric_states_array.at(i + adl::VX);
+    auto & vy = agent_centric_states_array.at(i + adl::VY);
+    auto & ax = agent_centric_states_array.at(i + adl::AX);
+    auto & ay = agent_centric_states_array.at(i + adl::AY);
+    auto & z = agent_centric_states_array.at(i + adl::Z);
+    auto & yaw = agent_centric_states_array.at(i + adl::YAW);
+
+    std::tie(x, y) = transform2D({x, y}, {ref_x, ref_y}, {cos, sin});
+    std::tie(vx, vy) = transform2D({vx, vy}, {0.0, 0.0}, {cos, sin});
+    std::tie(ax, ay) = transform2D({x, y}, {0.0, 0.0}, {cos, sin});
+
+    z -= ref_z;
+    yaw -= ref_yaw;
+  }
+  return agent_centric_history;
+};
+
+/**
+ * @brief Get histories with agent states in the reference frame of the last state
+ *
+ * @param histories vector of histories to modify.
+ * @return  vector of histories, each in the reference frame of the last state.
+ */
+[[nodiscard]] inline std::vector<AgentHistory> getAgentCentricHistories(
+  const std::vector<AgentHistory> & histories)
+{
+  std::vector<AgentHistory> agent_centric_histories;
+  agent_centric_histories.reserve(histories.size());
+  for (const auto & history : histories) {
+    const auto & reference_state =
+      history.get_latest_state();  // Todo(Daniel): should it be the latest VALID state?
+    agent_centric_histories.push_back(getAgentCentricHistory(history, reference_state));
+  }
+  return agent_centric_histories;
+};
+
+}  // namespace autoware::mtr

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -15,6 +15,7 @@
 #include "autoware/mtr/node.hpp"
 
 #include "autoware/mtr/agent.hpp"
+#include "autoware/mtr/conversions/history.hpp"
 #include "autoware/mtr/conversions/lanelet.hpp"
 #include "autoware/mtr/fixed_queue.hpp"
 
@@ -185,6 +186,8 @@ void MTRNode::callback(const TrackedObjects::ConstSharedPtr object_msg)
 
   const auto ego_index = static_cast<size_t>(tmp_ego_index);
   const auto relative_timestamps = getRelativeTimestamps();
+  // For testing purposes, normally pre-processing is done in the cuda side.
+  // const auto agent_centric_histories = getAgentCentricHistories(histories);
   AgentData agent_data(histories, ego_index, target_indices, label_ids, relative_timestamps);
 
   std::vector<PredictedTrajectory> trajectories;


### PR DESCRIPTION
Adds a method to calculate agent centric history in the c++ side. It will mostly be used for easy comparison with the cuda implementation.