### PR TITLE
fix/cuda pointer data

### DIFF
--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -121,7 +121,7 @@ struct AgentState
   float ay() const { return acceleration_.y; }
 
   // Return `true` if the value is `1.0`.
-  bool is_valid() const { return is_valid_ == 1.0; }
+  bool is_valid() const { return is_valid_ > std::numeric_limits<float>::epsilon(); }
 
   // Return the state attribute as an array.
   std::array<float, AgentStateDim> as_array() const noexcept

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -164,6 +164,14 @@ struct AgentHistory
     queue_.push_back(state);
   }
 
+  ~AgentHistory() = default;
+
+  AgentHistory(const AgentHistory & other) = default;
+  AgentHistory & operator=(const AgentHistory & other) = delete;
+
+  AgentHistory(AgentHistory && other) noexcept = default;
+  AgentHistory & operator=(AgentHistory && other) noexcept = delete;
+
   // Return the history time length `T`.
   size_t length() const { return max_time_length_; }
 

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -62,7 +62,7 @@ struct AgentState
   {
     position_.x = info_array.at(0);
     position_.y = info_array.at(1);
-    position_.z = 0.0;
+    position_.z = info_array.at(2);
     dimension_.x = info_array.at(3);
     dimension_.y = info_array.at(4);
     dimension_.z = info_array.at(5);

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -62,7 +62,7 @@ struct AgentState
   {
     position_.x = info_array.at(0);
     position_.y = info_array.at(1);
-    position_.z = info_array.at(2);
+    position_.z = 0.0;
     dimension_.x = info_array.at(3);
     dimension_.y = info_array.at(4);
     dimension_.z = info_array.at(5);

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -56,7 +56,23 @@ enum AgentDimLabels {
 struct AgentState
 {
   // Construct a new instance filling all elements by `0.0f`.
-  AgentState() {}
+  AgentState() = default;
+
+  explicit AgentState(const std::vector<float> & info_array)
+  {
+    position_.x = info_array.at(0);
+    position_.y = info_array.at(1);
+    position_.z = info_array.at(2);
+    dimension_.x = info_array.at(3);
+    dimension_.y = info_array.at(4);
+    dimension_.z = info_array.at(5);
+    yaw_ = info_array.at(6);
+    velocity_.x = info_array.at(7);
+    velocity_.y = info_array.at(8);
+    acceleration_.x = info_array.at(9);
+    acceleration_.y = info_array.at(10);
+    is_valid_ = info_array.at(11);
+  }
 
   /**
    * @brief Construct a new instance with specified values.
@@ -152,6 +168,25 @@ struct AgentHistory
    * @param current_time Current timestamp.
    * @param max_time_length History length.
    */
+  AgentHistory(
+    const std::vector<float> & state_array, const std::string & object_id, const size_t label_id,
+    const double current_time, const size_t max_time_length)
+  : object_id_(object_id),
+    label_id_(label_id),
+    latest_time_(current_time),
+    max_time_length_(max_time_length)
+  {
+    queue_.set_size(max_time_length);
+    for (size_t i = 0; i < max_time_length; ++i) {
+      const auto start = i * AgentStateDim;
+      const auto end = start + AgentStateDim;
+      const AgentState state(std::vector<float>(
+        state_array.begin() + static_cast<std::vector<float>::difference_type>(start),
+        state_array.begin() + static_cast<std::vector<float>::difference_type>(end)));
+      queue_.push_back(state);
+    }
+  }
+
   AgentHistory(
     const AgentState & state, const std::string & object_id, const size_t label_id,
     const double current_time, const size_t max_time_length)

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -184,6 +184,7 @@ struct AgentHistory
         state_array.begin() + static_cast<std::vector<float>::difference_type>(start),
         state_array.begin() + static_cast<std::vector<float>::difference_type>(end)));
       queue_.push_back(state);
+      is_valid_latest_ = state.is_valid();
     }
   }
 
@@ -197,6 +198,7 @@ struct AgentHistory
   {
     queue_.set_size(max_time_length);
     queue_.push_back(state);
+    is_valid_latest_ = state.is_valid();
   }
 
   ~AgentHistory() = default;
@@ -283,7 +285,7 @@ struct AgentHistory
    * @return true If the end of element is 1.0f.
    * @return false Otherwise.
    */
-  bool is_valid_latest() const { return get_latest_state().is_valid(); }
+  bool is_valid_latest() const { return is_valid_latest_; }
 
   // Get the latest agent state at `T`.
   const AgentState & get_latest_state() const { return queue_.back(); }
@@ -302,6 +304,7 @@ private:
   const size_t label_id_;
   double latest_time_;
   const size_t max_time_length_;
+  bool is_valid_latest_{false};
   FixedQueue<AgentState> queue_;
 };
 

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -158,9 +158,9 @@ struct AgentHistory
   : object_id_(object_id),
     label_id_(label_id),
     latest_time_(current_time),
-    max_time_length_(max_time_length),
-    queue_(FixedQueue<AgentState>(max_time_length))
+    max_time_length_(max_time_length)
   {
+    queue_.set_size(max_time_length);
     queue_.push_back(state);
   }
 

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -24,7 +24,6 @@
 #include <array>
 #include <cstddef>
 #include <limits>
-#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -142,9 +141,8 @@ private:
 /**
  * @brief A class to represent the state history of an agent.
  */
-class AgentHistory
+struct AgentHistory
 {
-public:
   /**
    * @brief Construct a new Agent History filling the latest state by input state.
    *
@@ -161,9 +159,9 @@ public:
     label_id_(label_id),
     latest_time_(current_time),
     max_time_length_(max_time_length),
-    queue_ptr_(std::make_unique<FixedQueue<AgentState>>(FixedQueue<AgentState>(max_time_length)))
+    queue_(FixedQueue<AgentState>(max_time_length))
   {
-    queue_ptr_->push_back(state);
+    queue_.push_back(state);
   }
 
   ~AgentHistory() = default;
@@ -207,7 +205,7 @@ public:
    */
   void update(double current_time, const AgentState & state) noexcept
   {
-    queue_ptr_->push_back(state);
+    queue_.push_back(state);
     latest_time_ = current_time;
   }
 
@@ -215,14 +213,14 @@ public:
   void update_empty() noexcept
   {
     const auto state = AgentState::empty();
-    queue_ptr_->push_back(state);
+    queue_.push_back(state);
   }
 
   // Return a history states as an array.
   std::vector<float> as_array() const noexcept
   {
     std::vector<float> output;
-    for (const auto & state : *queue_ptr_) {
+    for (const auto & state : queue_) {
       for (const auto & v : state.as_array()) {
         output.push_back(v);
       }
@@ -240,6 +238,7 @@ public:
    */
   bool is_ancient(double current_time, double threshold) const
   {
+    /* TODO: Raise error if the current time is smaller than latest */
     return current_time - latest_time_ >= threshold;
   }
 
@@ -249,7 +248,7 @@ public:
    * @return true If the end of element is 1.0f.
    * @return false Otherwise.
    */
-  bool is_valid_latest() const { return queue_ptr_->end()->is_valid(); }
+  bool is_valid_latest() const { return get_latest_state().is_valid(); }
 
   // Get the latest agent state at `T`.
   const AgentState & get_latest_state() const { return queue_.back(); }
@@ -258,10 +257,9 @@ public:
   std::optional<AgentState> get_latest_valid_state() const
   {
     auto latest_valid_state = std::find_if(
-      queue_ptr_->rbegin(), queue_ptr_->rend(),
-      [](const auto & state) { return state.is_valid(); });
-    return (latest_valid_state != queue_ptr_->rend()) ? std::make_optional(*latest_valid_state)
-                                                      : std::nullopt;
+      queue_.rbegin(), queue_.rend(), [](const auto & state) { return state.is_valid(); });
+    return (latest_valid_state != queue_.rend()) ? std::make_optional(*latest_valid_state)
+                                                 : std::nullopt;
   }
 
 private:
@@ -269,7 +267,7 @@ private:
   const size_t label_id_;
   double latest_time_;
   const size_t max_time_length_;
-  const std::unique_ptr<FixedQueue<AgentState>> queue_ptr_;
+  FixedQueue<AgentState> queue_;
 };
 
 /**

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -280,7 +280,7 @@ struct AgentData
     const std::vector<AgentHistory> & histories, const size_t ego_index,
     const std::vector<size_t> & target_indices, const std::vector<size_t> & label_ids,
     const std::vector<float> & timestamps)
-  : num_target_(target_indices.size()),
+  : num_target_(target_indices.size() + 1),  // NPC targets + Ego
     num_agent_(histories.size()),
     time_length_(timestamps.size()),
     ego_index_(ego_index),

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -280,7 +280,7 @@ struct AgentData
     const std::vector<AgentHistory> & histories, const size_t ego_index,
     const std::vector<size_t> & target_indices, const std::vector<size_t> & label_ids,
     const std::vector<float> & timestamps)
-  : num_target_(target_indices.size() + 1),  // NPC targets + Ego
+  : num_target_(target_indices.size()),
     num_agent_(histories.size()),
     time_length_(timestamps.size()),
     ego_index_(ego_index),

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <cstddef>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -141,8 +142,9 @@ private:
 /**
  * @brief A class to represent the state history of an agent.
  */
-struct AgentHistory
+class AgentHistory
 {
+public:
   /**
    * @brief Construct a new Agent History filling the latest state by input state.
    *
@@ -159,9 +161,9 @@ struct AgentHistory
     label_id_(label_id),
     latest_time_(current_time),
     max_time_length_(max_time_length),
-    queue_(FixedQueue<AgentState>(max_time_length))
+    queue_ptr_(std::make_unique<FixedQueue<AgentState>>(FixedQueue<AgentState>(max_time_length)))
   {
-    queue_.push_back(state);
+    queue_ptr_->push_back(state);
   }
 
   ~AgentHistory() = default;
@@ -205,7 +207,7 @@ struct AgentHistory
    */
   void update(double current_time, const AgentState & state) noexcept
   {
-    queue_.push_back(state);
+    queue_ptr_->push_back(state);
     latest_time_ = current_time;
   }
 
@@ -213,14 +215,14 @@ struct AgentHistory
   void update_empty() noexcept
   {
     const auto state = AgentState::empty();
-    queue_.push_back(state);
+    queue_ptr_->push_back(state);
   }
 
   // Return a history states as an array.
   std::vector<float> as_array() const noexcept
   {
     std::vector<float> output;
-    for (const auto & state : queue_) {
+    for (const auto & state : *queue_ptr_) {
       for (const auto & v : state.as_array()) {
         output.push_back(v);
       }
@@ -238,7 +240,6 @@ struct AgentHistory
    */
   bool is_ancient(double current_time, double threshold) const
   {
-    /* TODO: Raise error if the current time is smaller than latest */
     return current_time - latest_time_ >= threshold;
   }
 
@@ -248,7 +249,7 @@ struct AgentHistory
    * @return true If the end of element is 1.0f.
    * @return false Otherwise.
    */
-  bool is_valid_latest() const { return get_latest_state().is_valid(); }
+  bool is_valid_latest() const { return queue_ptr_->end()->is_valid(); }
 
   // Get the latest agent state at `T`.
   const AgentState & get_latest_state() const { return queue_.back(); }
@@ -257,9 +258,10 @@ struct AgentHistory
   std::optional<AgentState> get_latest_valid_state() const
   {
     auto latest_valid_state = std::find_if(
-      queue_.rbegin(), queue_.rend(), [](const auto & state) { return state.is_valid(); });
-    return (latest_valid_state != queue_.rend()) ? std::make_optional(*latest_valid_state)
-                                                 : std::nullopt;
+      queue_ptr_->rbegin(), queue_ptr_->rend(),
+      [](const auto & state) { return state.is_valid(); });
+    return (latest_valid_state != queue_ptr_->rend()) ? std::make_optional(*latest_valid_state)
+                                                      : std::nullopt;
   }
 
 private:
@@ -267,7 +269,7 @@ private:
   const size_t label_id_;
   double latest_time_;
   const size_t max_time_length_;
-  FixedQueue<AgentState> queue_;
+  const std::unique_ptr<FixedQueue<AgentState>> queue_ptr_;
 };
 
 /**

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -155,11 +155,11 @@ struct AgentHistory
   AgentHistory(
     const AgentState & state, const std::string & object_id, const size_t label_id,
     const double current_time, const size_t max_time_length)
-  : queue_(max_time_length),
-    object_id_(object_id),
+  : object_id_(object_id),
     label_id_(label_id),
     latest_time_(current_time),
-    max_time_length_(max_time_length)
+    max_time_length_(max_time_length),
+    queue_(FixedQueue<AgentState>(max_time_length))
   {
     queue_.push_back(state);
   }
@@ -263,11 +263,11 @@ struct AgentHistory
   }
 
 private:
-  FixedQueue<AgentState> queue_;
   const std::string object_id_;
   const size_t label_id_;
   double latest_time_;
   const size_t max_time_length_;
+  FixedQueue<AgentState> queue_;
 };
 
 /**

--- a/include/autoware/mtr/conversions/lanelet.hpp
+++ b/include/autoware/mtr/conversions/lanelet.hpp
@@ -41,6 +41,9 @@ namespace autoware::mtr
 inline void insertLanePoints(
   const std::vector<LanePoint> & points, std::vector<LanePoint> & container)
 {
+  if (points.empty()) {
+    return;
+  }
   container.reserve(container.size() * 2);
   container.insert(container.end(), points.begin(), points.end());
 }

--- a/include/autoware/mtr/conversions/lanelet.hpp
+++ b/include/autoware/mtr/conversions/lanelet.hpp
@@ -209,8 +209,8 @@ private:
    * @return std::vector<LanePoint>
    */
   std::vector<LanePoint> fromLinestring(
-    const lanelet::ConstLineString3d & linestring, const geometry_msgs::msg::Point & position,
-    double distance_threshold) const noexcept;
+    const lanelet::ConstLineString3d & linestring, const float polyline_label,
+    const geometry_msgs::msg::Point & position, double distance_threshold) const noexcept;
 
   /**
    * @brief Convert a polygon to the set of polylines.

--- a/include/autoware/mtr/conversions/lanelet.hpp
+++ b/include/autoware/mtr/conversions/lanelet.hpp
@@ -221,8 +221,8 @@ private:
    * @return std::vector<LanePoint>
    */
   std::vector<LanePoint> fromPolygon(
-    const lanelet::CompoundPolygon3d & polygon, const geometry_msgs::msg::Point & position,
-    double distance_threshold) const noexcept;
+    const lanelet::CompoundPolygon3d & polygon, const float label_id,
+    const geometry_msgs::msg::Point & position, double distance_threshold) const noexcept;
 
   lanelet::LaneletMapConstPtr lanelet_map_ptr_;  //!< Pointer of lanelet map.
   size_t max_num_polyline_;                      //!< The max number of polylines.

--- a/include/autoware/mtr/fixed_queue.hpp
+++ b/include/autoware/mtr/fixed_queue.hpp
@@ -36,6 +36,14 @@ public:
 
   explicit FixedQueue(size_type size) : queue_(size) {}
 
+  ~FixedQueue() = default;
+
+  FixedQueue(const FixedQueue & other) = default;
+  FixedQueue & operator=(const FixedQueue & other) = default;
+
+  FixedQueue(FixedQueue && other) noexcept = default;
+  FixedQueue & operator=(FixedQueue && other) noexcept = default;
+
   void push_back(const T && t) noexcept
   {
     queue_.pop_front();

--- a/include/autoware/mtr/fixed_queue.hpp
+++ b/include/autoware/mtr/fixed_queue.hpp
@@ -15,7 +15,6 @@
 #ifndef AUTOWARE__MTR__FIXED_QUEUE_HPP_
 #define AUTOWARE__MTR__FIXED_QUEUE_HPP_
 
-#include <cstddef>
 #include <deque>
 #include <iterator>
 
@@ -34,22 +33,13 @@ public:
   using const_iterator = typename std::deque<T>::const_iterator;
   using rconst_iterator = typename std::reverse_iterator<const_iterator>;
 
-  explicit FixedQueue(size_t size) : size_(size) { queue_.resize(size); }
+  explicit FixedQueue(size_t size) : size_(size) {}
 
-  explicit FixedQueue() = default;
-
+  FixedQueue() = default;
   ~FixedQueue() = default;
 
-  FixedQueue(const FixedQueue & other) { queue_ = other.queue_; }
-
-  FixedQueue & operator=(const FixedQueue & other)
-  {
-    if (this != &other) {
-      queue_ = other.queue_;
-      size_ = other.size_;
-    }
-    return *this;
-  }
+  FixedQueue(const FixedQueue & other) = default;
+  FixedQueue & operator=(const FixedQueue & other) = default;
 
   FixedQueue(FixedQueue && other) noexcept = default;
   FixedQueue & operator=(FixedQueue && other) noexcept = default;
@@ -103,12 +93,16 @@ public:
   void set_size(size_t size)
   {
     size_ = size;
-    queue_.resize(size);
+    while (queue_.size() > size_) {
+      queue_.pop_front();
+    }
   }
 
 private:
   std::deque<T> queue_;
-  size_t size_;
+  size_t size_ = 0;
 };
+
 }  // namespace autoware::mtr
+
 #endif  // AUTOWARE__MTR__FIXED_QUEUE_HPP_

--- a/include/autoware/mtr/fixed_queue.hpp
+++ b/include/autoware/mtr/fixed_queue.hpp
@@ -34,23 +34,33 @@ public:
   using const_iterator = typename std::deque<T>::const_iterator;
   using rconst_iterator = typename std::reverse_iterator<const_iterator>;
 
-  explicit FixedQueue(size_type size) : queue_(size) {}
+  explicit FixedQueue(size_t size) : size_(size) { queue_.resize(size); }
 
   ~FixedQueue() = default;
 
-  FixedQueue(const FixedQueue & other) = default;
-  FixedQueue & operator=(const FixedQueue & other) = default;
+  FixedQueue(const FixedQueue & other) { queue_ = other.queue_; }
+
+  FixedQueue & operator=(const FixedQueue & other)
+  {
+    if (this != &other) {
+      queue_ = other.queue_;
+      size_ = other.size_;
+    }
+    return *this;
+  }
 
   FixedQueue(FixedQueue && other) noexcept = default;
   FixedQueue & operator=(FixedQueue && other) noexcept = default;
 
-  void push_back(const T && t) noexcept
+  void push_back(const T & t) noexcept
   {
-    queue_.pop_front();
+    if (queue_.size() == size_) {
+      queue_.pop_front();
+    }
     queue_.push_back(t);
   }
 
-  void push_back(const T & t) noexcept
+  void push_back(const T && t) noexcept
   {
     queue_.pop_front();
     queue_.push_back(t);
@@ -90,6 +100,7 @@ public:
 
 private:
   std::deque<T> queue_;
+  size_t size_;
 };
 }  // namespace autoware::mtr
 #endif  // AUTOWARE__MTR__FIXED_QUEUE_HPP_

--- a/include/autoware/mtr/fixed_queue.hpp
+++ b/include/autoware/mtr/fixed_queue.hpp
@@ -36,6 +36,8 @@ public:
 
   explicit FixedQueue(size_t size) : size_(size) { queue_.resize(size); }
 
+  explicit FixedQueue() = default;
+
   ~FixedQueue() = default;
 
   FixedQueue(const FixedQueue & other) { queue_ = other.queue_; }
@@ -97,6 +99,12 @@ public:
   rconst_iterator rend() const noexcept { return queue_.rend(); }
 
   size_type size() const noexcept { return queue_.size(); }
+
+  void set_size(size_t size)
+  {
+    size_ = size;
+    queue_.resize(size);
+  }
 
 private:
   std::deque<T> queue_;

--- a/include/autoware/mtr/utils.hpp
+++ b/include/autoware/mtr/utils.hpp
@@ -86,7 +86,7 @@ inline void print_agent_data(const AgentData & agent_data)
 
   const auto & d = agent_data.state_dim();
   const auto & t = agent_data.time_length();
-  const auto target_data_ptr = agent_data.target_data_ptr();
+  const auto target_data_ptr = agent_data.full_target_data_ptr();
   const auto ego_data_ptr = agent_data.ego_data_ptr();
   std::vector<float> ego_data(d * t);
   std::copy(ego_data_ptr, ego_data_ptr + (d * t), ego_data.begin());

--- a/include/autoware/mtr/utils.hpp
+++ b/include/autoware/mtr/utils.hpp
@@ -87,9 +87,9 @@ inline void print_agent_data(const AgentData & agent_data)
   print_data(ego_data_ptr, "EGO", t);
   for (const auto & idx : agent_data.target_indices()) {
     // Compute the starting address of the n-th object's data
-    auto object_data = new float[d * t];
+    std::vector<float> object_data(d * t);
     const float * object_start = target_data_ptr + (idx * d * t);
-    std::memcpy(object_data, object_start, d * t * sizeof(float));
+    std::copy(object_start, object_start + (d * t), object_data.begin());
     print_data(object_data, "object# " + std::to_string(idx), t);
   }
 }

--- a/include/autoware/mtr/utils.hpp
+++ b/include/autoware/mtr/utils.hpp
@@ -39,18 +39,22 @@ namespace autoware::mtr::utils
 {
 
 inline void print_data(
-  const float * data, const std::string & obj_name, const size_t num_timestamps = 1)
+  const std::vector<float> & data, const std::string & obj_name, const size_t num_timestamps = 1)
 {
-  static const std::array<std::string, 12> state_data_names{"x_",     "y_",      "z_",   "length_",
-                                                  "width_", "height_", "yaw_", "vx_",
-                                                  "vy_",    "ax_",     "ay_",  "is_valid_"};
+  static const std::array<std::string, 12> state_data_names{
+    "x_",   "y_",  "z_",  "length_", "width_", "height_",
+    "yaw_", "vx_", "vy_", "ax_",     "ay_",    "is_valid_"};
 
+  if (static_cast<size_t>(data.size()) != num_timestamps * state_data_names.size()) {
+    std::cerr << "Data size mismatch\n";
+    return;
+  }
   std::cerr << "-----------------\n";
   std::cerr << "Object " << obj_name << "\n";
   for (size_t t = 0; t < num_timestamps; ++t) {
     size_t i{0};
     for (const auto & name : state_data_names) {
-      std::cerr << name << " " << data[t * state_data_names.size() + i] << ",";
+      std::cerr << name << " " << data.at(t * state_data_names.size() + i) << ",";
       ++i;
     }
     std::cerr << "\n-----------------\n";
@@ -84,7 +88,10 @@ inline void print_agent_data(const AgentData & agent_data)
   const auto & t = agent_data.time_length();
   const auto target_data_ptr = agent_data.target_data_ptr();
   const auto ego_data_ptr = agent_data.ego_data_ptr();
-  print_data(ego_data_ptr, "EGO", t);
+  std::vector<float> ego_data(d * t);
+  std::copy(ego_data_ptr, ego_data_ptr + (d * t), ego_data.begin());
+
+  print_data(ego_data, "EGO", t);
   for (const auto & idx : agent_data.target_indices()) {
     // Compute the starting address of the n-th object's data
     std::vector<float> object_data(d * t);

--- a/include/autoware/mtr/utils.hpp
+++ b/include/autoware/mtr/utils.hpp
@@ -41,7 +41,7 @@ namespace autoware::mtr::utils
 inline void print_data(
   const float * data, const std::string & obj_name, const size_t num_timestamps = 1)
 {
-  const std::vector<std::string> state_data_names{"x_",     "y_",      "z_",   "length_",
+  static const std::array<std::string, 12> state_data_names{"x_",     "y_",      "z_",   "length_",
                                                   "width_", "height_", "yaw_", "vx_",
                                                   "vy_",    "ax_",     "ay_",  "is_valid_"};
 

--- a/include/autoware/mtr/utils.hpp
+++ b/include/autoware/mtr/utils.hpp
@@ -1,0 +1,99 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef AUTOWARE__MTR__UTILS_HPP_
+#define AUTOWARE__MTR__UTILS_HPP_
+
+#include "autoware/mtr/agent.hpp"
+#include "autoware/mtr/node.hpp"
+
+#include <lanelet2_extension/utility/message_conversion.hpp>
+
+#include <geometry_msgs/msg/detail/pose__struct.hpp>
+#include <geometry_msgs/msg/detail/twist__struct.hpp>
+#include <geometry_msgs/msg/detail/twist_with_covariance__struct.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include <tf2/utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace autoware::mtr::utils
+{
+
+inline void print_data(
+  const float * data, const std::string & obj_name, const size_t num_timestamps = 1)
+{
+  const std::vector<std::string> state_data_names{"x_",     "y_",      "z_",   "length_",
+                                                  "width_", "height_", "yaw_", "vx_",
+                                                  "vy_",    "ax_",     "ay_",  "is_valid_"};
+
+  std::cerr << "-----------------\n";
+  std::cerr << "Object " << obj_name << "\n";
+  for (size_t t = 0; t < num_timestamps; ++t) {
+    size_t i{0};
+    for (const auto & name : state_data_names) {
+      std::cerr << name << " " << data[t * state_data_names.size() + i] << ",";
+      ++i;
+    }
+    std::cerr << "\n-----------------\n";
+  }
+};
+
+inline void print_agent_data(const AgentData & agent_data)
+{
+  std::cerr << "num agents " << agent_data.num_agent() << "\n";
+  std::cerr << "num targets " << agent_data.num_target() << "\n";
+  std::cerr << "time_length_ " << agent_data.time_length() << "\n";
+  std::cerr << "ego_index_ " << agent_data.ego_index() << "\n";
+  std::cerr << "target index(" << agent_data.target_indices().size() << "): ";
+  for (const auto target : agent_data.target_indices()) {
+    std::cerr << target << ",";
+  }
+  std::cerr << "\n";
+
+  std::cerr << "label index(" << agent_data.label_ids().size() << "): ";
+  for (const auto label : agent_data.label_ids()) {
+    std::cerr << label << ",";
+  }
+  std::cerr << "\n";
+  std::cerr << "timestamps(" << agent_data.timestamps().size() << "): ";
+  for (const auto timestamps : agent_data.timestamps()) {
+    std::cerr << timestamps << ",";
+  }
+  std::cerr << "\n";
+
+  const auto & d = agent_data.state_dim();
+  const auto & t = agent_data.time_length();
+  const auto target_data_ptr = agent_data.target_data_ptr();
+  const auto ego_data_ptr = agent_data.ego_data_ptr();
+  print_data(ego_data_ptr, "EGO", t);
+  for (const auto & idx : agent_data.target_indices()) {
+    // Compute the starting address of the n-th object's data
+    auto object_data = new float[d * t];
+    const float * object_start = target_data_ptr + (idx * d * t);
+    std::memcpy(object_data, object_start, d * t * sizeof(float));
+    print_data(object_data, "object# " + std::to_string(idx), t);
+  }
+}
+
+}  // namespace autoware::mtr::utils
+
+#endif  // AUTOWARE__MTR__UTILS_HPP_

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -77,7 +77,7 @@ __global__ void agentPreprocessKernel(
   const int onehot_idx = out_idx + 6;
   out_data[onehot_idx + object_type_index[n]] = 1.0f;
 
-  if (target_index[b] == n) {
+  if (b == n) {
     out_data[onehot_idx + C] = 1.0f;
   }
 

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -33,7 +33,7 @@ __global__ void agentPreprocessKernel(
 
   // === out data ===
   // --- transform trajectory to target centric coords ---
-  const int src_trajectory_idx = (b * T + t) * D;
+  const int src_trajectory_idx = (n * T + t) * D;
   const float x = in_trajectory[src_trajectory_idx];
   const float y = in_trajectory[src_trajectory_idx + 1];
   const float z = in_trajectory[src_trajectory_idx + 2];

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -53,14 +53,14 @@ __global__ void agentPreprocessKernel(
   const float center_y = in_trajectory[center_idx + 1];
   const float center_z = in_trajectory[center_idx + 2];
   const float center_yaw = in_trajectory[center_idx + 6];
-  const float center_cos = cos(center_yaw);
-  const float center_sin = sin(center_yaw);
+  const float trans_yaw = yaw - center_yaw;
+  const float center_cos = cos(trans_yaw);
+  const float center_sin = sin(trans_yaw);
 
   // do transform
   const float trans_x = center_cos * (x - center_x) - center_sin * (y - center_y);
   const float trans_y = center_sin * (x - center_x) + center_cos * (y - center_y);
   const float trans_z = z - center_z;
-  const float trans_yaw = yaw - center_yaw;
   const float trans_vx = center_cos * vx - center_sin * vy;
   const float trans_vy = center_sin * vx + center_cos * vy;
   const float trans_ax = center_cos * ax - center_sin * ay;

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -53,14 +53,14 @@ __global__ void agentPreprocessKernel(
   const float center_y = in_trajectory[center_idx + 1];
   const float center_z = in_trajectory[center_idx + 2];
   const float center_yaw = in_trajectory[center_idx + 6];
-  const float trans_yaw = yaw - center_yaw;
-  const float center_cos = cos(trans_yaw);
-  const float center_sin = sin(trans_yaw);
+  const float center_cos = cos(center_yaw);
+  const float center_sin = sin(center_yaw);
 
   // do transform
   const float trans_x = center_cos * (x - center_x) - center_sin * (y - center_y);
   const float trans_y = center_sin * (x - center_x) + center_cos * (y - center_y);
   const float trans_z = z - center_z;
+  const float trans_yaw = yaw - center_yaw;
   const float trans_vx = center_cos * vx - center_sin * vy;
   const float trans_vy = center_sin * vx + center_cos * vy;
   const float trans_ax = center_cos * ax - center_sin * ay;
@@ -102,7 +102,7 @@ __global__ void agentPreprocessKernel(
 
   // === mask ===
   const int mask_idx = b * N * T + n * T + t;
-  out_mask[mask_idx] = is_valid == 1.0f;
+  out_mask[mask_idx] = is_valid == 1.0f ? true : false;
 
   // === last pos ===
   if (t == T - 1) {

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -33,7 +33,7 @@ __global__ void agentPreprocessKernel(
 
   // === out data ===
   // --- transform trajectory to target centric coords ---
-  const int src_trajectory_idx = (b * T + t) * D;
+  const int src_trajectory_idx = (n * T + t) * D;  // TODO(Daniel): b or n ?
   const float x = in_trajectory[src_trajectory_idx];
   const float y = in_trajectory[src_trajectory_idx + 1];
   const float z = in_trajectory[src_trajectory_idx + 2];
@@ -48,7 +48,9 @@ __global__ void agentPreprocessKernel(
   const float is_valid = in_trajectory[src_trajectory_idx + 11];
 
   // extract targets trajectories
-  const int center_idx = (n * T + T - 1) * D;
+  // const int center_idx = (n * T + T - 1) * D; TODO(Daniel): Is this correct? or is bottom
+  // correct?
+  const int center_idx = (target_index[b] * T + T - 1) * D;
   const float center_x = in_trajectory[center_idx];
   const float center_y = in_trajectory[center_idx + 1];
   const float center_z = in_trajectory[center_idx + 2];

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -48,7 +48,7 @@ __global__ void agentPreprocessKernel(
   const float is_valid = in_trajectory[src_trajectory_idx + 11];
 
   // extract targets trajectories
-  const int center_idx = (target_index[b] * T + T - 1) * D;
+  const int center_idx = (n * T + T - 1) * D;
   const float center_x = in_trajectory[center_idx];
   const float center_y = in_trajectory[center_idx + 1];
   const float center_z = in_trajectory[center_idx + 2];

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -33,7 +33,7 @@ __global__ void agentPreprocessKernel(
 
   // === out data ===
   // --- transform trajectory to target centric coords ---
-  const int src_trajectory_idx = (n * T + t) * D;
+  const int src_trajectory_idx = (b * T + t) * D;
   const float x = in_trajectory[src_trajectory_idx];
   const float y = in_trajectory[src_trajectory_idx + 1];
   const float z = in_trajectory[src_trajectory_idx + 2];

--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -48,7 +48,7 @@ __global__ void agentPreprocessKernel(
   const float is_valid = in_trajectory[src_trajectory_idx + 11];
 
   // extract targets trajectories
-  const int center_idx = (n * T + T - 1) * D;
+  const int center_idx = (target_index[b] * T + T - 1) * D;
   const float center_x = in_trajectory[center_idx];
   const float center_y = in_trajectory[center_idx + 1];
   const float center_z = in_trajectory[center_idx + 2];
@@ -77,7 +77,7 @@ __global__ void agentPreprocessKernel(
   const int onehot_idx = out_idx + 6;
   out_data[onehot_idx + object_type_index[n]] = 1.0f;
 
-  if (b == n) {
+  if (target_index[b] == n) {
     out_data[onehot_idx + C] = 1.0f;
   }
 

--- a/src/conversions/history.cpp
+++ b/src/conversions/history.cpp
@@ -101,7 +101,7 @@ using adl = autoware::mtr::AgentDimLabels;
   std::vector<AgentHistory> agent_centric_histories;
   agent_centric_histories.reserve(histories.size());
   for (const auto & history : histories) {
-    const auto & reference_state =
+    const auto reference_state =
       history.get_latest_state();  // Todo(Daniel): should it be the latest VALID state?
     agent_centric_histories.push_back(getAgentCentricHistory(history, reference_state));
   }

--- a/src/conversions/lanelet.cpp
+++ b/src/conversions/lanelet.cpp
@@ -18,12 +18,86 @@
 
 #include <geometry_msgs/msg/detail/point__struct.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <optional>
 #include <vector>
 
 namespace autoware::mtr
 {
+
+bool isVirtualLinestring(const std::string & line_type, const std::string & line_subtype)
+{
+  // Indicate whether input linestring type and subtype is virtual.
+  // Args:
+  //   line_type (str): Line type name.
+  //   line_subtype (str): Line subtype name.
+  // Returns:
+  //   bool: Return True if line type is `virtual` and subtype is `""`.
+  return line_type == "virtual" && line_subtype == "";
+}
+
+bool isRoadedgeLinestring(const std::string & line_type)
+{
+  // Indicate whether input linestring type and subtype is supported RoadEdge.
+  // Args:
+  //   line_type (str): Line type name.
+  //   line_subtype (str): Line subtype name.
+  // Returns:
+  //   bool: Return True if line type is contained in T4RoadEdge.
+  return std::find(T4_ROADEDGE.begin(), T4_ROADEDGE.end(), line_type) != T4_ROADEDGE.end();
+}
+
+bool isRoadlineLinestring(const std::string & line_subtype)
+{
+  // Indicate whether input linestring type and subtype is supported RoadLine.
+  // Args:
+  //   line_type (str): Line type name.
+  //   line_subtype (str): Line subtype name.
+  // Returns:
+  //   bool: Return True if line subtype is contained in T4RoadLine.
+  // Note: Currently `line_type` is not used, but it might be used in the future.
+  return std::find(T4_ROADLINE.begin(), T4_ROADLINE.end(), line_subtype) != T4_ROADLINE.end();
+}
+
+std::string getLinestringType(const lanelet::ConstLineString3d & linestring)
+{
+  if (linestring.hasAttribute("type")) {
+    return linestring.attribute("type").value();
+  } else {
+    return "";
+  }
+}
+
+std::string getLinestringSubtype(const lanelet::ConstLineString3d & linestring)
+{
+  if (linestring.hasAttribute("subtype")) {
+    return linestring.attribute("subtype").value();
+  } else {
+    return "";
+  }
+}
+
+float getBoundaryType(const lanelet::ConstLineString3d & linestring)
+{
+  // Return the `BoundaryType` from linestring.
+  // Args:
+  //   linestring (lanelet::ConstLineString3d): LineString instance.
+  // Returns:
+  //   MapType: Boundary type.
+  auto line_type = getLinestringType(linestring);
+  auto line_subtype = getLinestringSubtype(linestring);
+  if (isVirtualLinestring(line_type, line_subtype)) {
+    return static_cast<float>(MapType::UNKNOWN);
+  } else if (isRoadedgeLinestring(line_type)) {
+    return static_cast<float>(autoware::mtr::g_map_type_mapping.at(line_type));
+  } else if (isRoadlineLinestring(line_subtype)) {
+    return static_cast<float>(autoware::mtr::g_map_type_mapping.at(line_subtype));
+  } else {
+    return static_cast<float>(MapType::UNKNOWN);
+  }
+}
+
 std::optional<PolylineData> LaneletConverter::convert(
   const geometry_msgs::msg::Point & position, double distance_threshold) const
 {
@@ -31,22 +105,29 @@ std::optional<PolylineData> LaneletConverter::convert(
   // parse lanelet layers
   for (const auto & lanelet : lanelet_map_ptr_->laneletLayer) {
     const auto lanelet_subtype = toSubtypeName(lanelet);
+    if (!lanelet_subtype || lanelet_subtype.value() == "walkway") {  // walkways are skipped
+      continue;
+    }
+    const auto label_id =
+      static_cast<float>(autoware::mtr::g_map_type_mapping.at(*lanelet_subtype));
+
     if (isLaneLike(lanelet_subtype)) {
       // convert centerlines
       if (isRoadwayLike(lanelet_subtype)) {
-        auto points = fromLinestring(lanelet.centerline3d(), position, distance_threshold);
+        auto points =
+          fromLinestring(lanelet.centerline3d(), label_id, position, distance_threshold);
         insertLanePoints(points, container);
       }
       // convert boundaries except of virtual lines
       if (!isTurnableIntersection(lanelet)) {
         const auto left_bound = lanelet.leftBound3d();
         if (isBoundaryLike(left_bound)) {
-          auto points = fromLinestring(left_bound, position, distance_threshold);
+          auto points = fromLinestring(left_bound, label_id, position, distance_threshold);
           insertLanePoints(points, container);
         }
         const auto right_bound = lanelet.rightBound3d();
         if (isBoundaryLike(right_bound)) {
-          auto points = fromLinestring(right_bound, position, distance_threshold);
+          auto points = fromLinestring(right_bound, label_id, position, distance_threshold);
           insertLanePoints(points, container);
         }
       }
@@ -59,7 +140,8 @@ std::optional<PolylineData> LaneletConverter::convert(
   // parse linestring layers
   for (const auto & linestring : lanelet_map_ptr_->lineStringLayer) {
     if (isBoundaryLike(linestring)) {
-      auto points = fromLinestring(linestring, position, distance_threshold);
+      const auto boundary_label = getBoundaryType(linestring);
+      auto points = fromLinestring(linestring, boundary_label, position, distance_threshold);
       insertLanePoints(points, container);
     }
   }
@@ -71,8 +153,8 @@ std::optional<PolylineData> LaneletConverter::convert(
 }
 
 std::vector<LanePoint> LaneletConverter::fromLinestring(
-  const lanelet::ConstLineString3d & linestring, const geometry_msgs::msg::Point & position,
-  double distance_threshold) const noexcept
+  const lanelet::ConstLineString3d & linestring, const float label_id,
+  const geometry_msgs::msg::Point & position, double distance_threshold) const noexcept
 {
   if (linestring.size() == 0) {
     return {};
@@ -100,7 +182,7 @@ std::vector<LanePoint> LaneletConverter::fromLinestring(
       dy /= (norm + epsilon);
       dz /= (norm + epsilon);
     }
-    output.emplace_back(itr->x(), itr->y(), itr->z(), dx, dy, dz, 0.0);  // TODO(ktro2828): Label ID
+    output.emplace_back(itr->x(), itr->y(), itr->z(), dx, dy, dz, label_id);
   }
   return output;
 }

--- a/src/conversions/lanelet.cpp
+++ b/src/conversions/lanelet.cpp
@@ -132,7 +132,7 @@ std::optional<PolylineData> LaneletConverter::convert(
         }
       }
     } else if (isCrosswalkLike(lanelet_subtype)) {
-      auto points = fromPolygon(lanelet.polygon3d(), position, distance_threshold);
+      auto points = fromPolygon(lanelet.polygon3d(), label_id, position, distance_threshold);
       insertLanePoints(points, container);
     }
   }
@@ -188,8 +188,8 @@ std::vector<LanePoint> LaneletConverter::fromLinestring(
 }
 
 std::vector<LanePoint> LaneletConverter::fromPolygon(
-  const lanelet::CompoundPolygon3d & polygon, const geometry_msgs::msg::Point & position,
-  double distance_threshold) const noexcept
+  const lanelet::CompoundPolygon3d & polygon, const float label_id,
+  const geometry_msgs::msg::Point & position, double distance_threshold) const noexcept
 {
   if (polygon.size() == 0) {
     return {};
@@ -217,7 +217,8 @@ std::vector<LanePoint> LaneletConverter::fromPolygon(
       dy /= (norm + epsilon);
       dz /= (norm + epsilon);
     }
-    output.emplace_back(itr->x(), itr->y(), itr->z(), dx, dy, dz, 0.0);  // TODO(ktro2828): Label ID
+    output.emplace_back(
+      itr->x(), itr->y(), itr->z(), dx, dy, dz, label_id);  // TODO(ktro2828): Label ID
   }
   return output;
 }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -179,15 +179,10 @@ void MTRNode::callback(const TrackedObjects::ConstSharedPtr object_msg)
   }
 
   const auto target_indices = extractTargetAgent(histories);
-<<<<<<< Updated upstream
-  if (target_indices.empty()) {
-    RCLCPP_WARN(get_logger(), "No target agents");
-=======
   if (target_indices.size() != NUM_TARGET) {
     RCLCPP_WARN(
       get_logger(), "Found target size mismatch, %zu targets were extracted, but %zu were expected",
       target_indices.size(), NUM_TARGET);
->>>>>>> Stashed changes
     return;
   }
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -166,7 +166,8 @@ void MTRNode::callback(const TrackedObjects::ConstSharedPtr object_msg)
   int tmp_ego_index = -1;
   for (const auto & [object_id, history] : agent_history_map_) {
     object_ids.emplace_back(object_id);
-    histories.emplace_back(history);
+    histories.emplace_back(
+      history.as_array(), object_id, history.label_id(), current_time, history.length());
     label_ids.emplace_back(history.label_id());
     if (object_id == EGO_ID) {
       tmp_ego_index = histories.size() - 1;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -18,6 +18,7 @@
 #include "autoware/mtr/conversions/history.hpp"
 #include "autoware/mtr/conversions/lanelet.hpp"
 #include "autoware/mtr/fixed_queue.hpp"
+#include "autoware/mtr/utils.hpp"
 
 #include <lanelet2_extension/utility/message_conversion.hpp>
 #include <rclcpp/logging.hpp>
@@ -192,7 +193,7 @@ void MTRNode::callback(const TrackedObjects::ConstSharedPtr object_msg)
   // For testing purposes, normally pre-processing is done in the cuda side.
   // const auto agent_centric_histories = getAgentCentricHistories(histories);
   AgentData agent_data(histories, ego_index, target_indices, label_ids, relative_timestamps);
-
+  autoware::mtr::utils::print_agent_data(agent_data);
   std::vector<PredictedTrajectory> trajectories;
   if (!model_ptr_->doInference(agent_data, *polyline_data, trajectories)) {
     RCLCPP_WARN(get_logger(), "Inference failed");
@@ -260,11 +261,17 @@ std::optional<TrackedObject> MTRNode::getLatestEgo()
 
   // Shape
   {
-    const auto & ego_max_long_offset = vehicle_info_.max_longitudinal_offset_m;
-    const auto & ego_rear_overhang = vehicle_info_.vehicle_height_m;
-    const auto & ego_length = vehicle_info_.vehicle_length_m;
-    const auto & ego_width = vehicle_info_.vehicle_width_m;
-    const auto & ego_height = vehicle_info_.vehicle_height_m;
+    // const auto & ego_max_long_offset = vehicle_info_.max_longitudinal_offset_m;
+    // const auto & ego_rear_overhang = vehicle_info_.vehicle_height_m;
+    // const auto & ego_length = vehicle_info_.vehicle_length_m;
+    // const auto & ego_width = vehicle_info_.vehicle_width_m;
+    // const auto & ego_height = vehicle_info_.vehicle_height_m;
+
+    const auto ego_max_long_offset = 2.9;
+    const auto ego_rear_overhang = 1.1;
+    const auto ego_length = 4.0;
+    const auto ego_width = 2.0;
+    const auto ego_height = 2.0;
 
     autoware_perception_msgs::msg::Shape shape;
     shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -41,7 +41,7 @@ namespace autoware::mtr
 {
 // TODO(ktro2828): use a parameter
 constexpr double TIME_THRESHOLD = 1.0;
-constexpr size_t MAX_NUM_TARGET = 1;
+constexpr size_t MAX_NUM_TARGET = 2;
 constexpr double POLYLINE_DISTANCE_THRESHOLD = 100.0;
 namespace
 {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -320,6 +320,19 @@ void MTRNode::updateAgentHistory(
   const TrackedObject & ego_msg)
 {
   std::vector<std::string> observed_ids;
+
+  // ego vehicle
+  observed_ids.emplace_back(EGO_ID);
+  object_msg_map_.insert_or_assign(EGO_ID, ego_msg);
+
+  const auto ego = createAgentState(ego_msg, true);
+  if (agent_history_map_.count(EGO_ID) == 0) {
+    AgentHistory history(ego, EGO_ID, AgentLabel::VEHICLE, current_time, config_ptr_->num_past);
+    agent_history_map_.emplace(EGO_ID, history);
+  } else {
+    agent_history_map_.at(EGO_ID).update(current_time, ego);
+  }
+
   // other agents
   for (const auto & object : objects_msg->objects) {
     auto label_index = getLabelIndex(object);
@@ -338,18 +351,6 @@ void MTRNode::updateAgentHistory(
     } else {
       agent_history_map_.at(object_id).update(current_time, state);
     }
-  }
-
-  // ego vehicle
-  observed_ids.emplace_back(EGO_ID);
-  object_msg_map_.insert_or_assign(EGO_ID, ego_msg);
-
-  const auto ego = createAgentState(ego_msg, true);
-  if (agent_history_map_.count(EGO_ID) == 0) {
-    AgentHistory history(ego, EGO_ID, AgentLabel::VEHICLE, current_time, config_ptr_->num_past);
-    agent_history_map_.emplace(EGO_ID, history);
-  } else {
-    agent_history_map_.at(EGO_ID).update(current_time, ego);
   }
 
   // update unobserved histories with empty

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -41,7 +41,7 @@ namespace autoware::mtr
 {
 // TODO(ktro2828): use a parameter
 constexpr double TIME_THRESHOLD = 1.0;
-constexpr size_t MAX_NUM_TARGET = 2;
+constexpr size_t NUM_TARGET = 2;
 constexpr double POLYLINE_DISTANCE_THRESHOLD = 100.0;
 namespace
 {
@@ -179,8 +179,15 @@ void MTRNode::callback(const TrackedObjects::ConstSharedPtr object_msg)
   }
 
   const auto target_indices = extractTargetAgent(histories);
+<<<<<<< Updated upstream
   if (target_indices.empty()) {
     RCLCPP_WARN(get_logger(), "No target agents");
+=======
+  if (target_indices.size() != NUM_TARGET) {
+    RCLCPP_WARN(
+      get_logger(), "Found target size mismatch, %zu targets were extracted, but %zu were expected",
+      target_indices.size(), NUM_TARGET);
+>>>>>>> Stashed changes
     return;
   }
 
@@ -388,7 +395,7 @@ std::vector<size_t> MTRNode::extractTargetAgent(const std::vector<AgentHistory> 
   std::vector<size_t> target_indices;
   for (const auto & [idx, _] : index_distances) {
     target_indices.emplace_back(idx);
-    if (MAX_NUM_TARGET <= target_indices.size()) {
+    if (NUM_TARGET <= target_indices.size()) {
       break;
     }
   }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -193,7 +193,6 @@ void MTRNode::callback(const TrackedObjects::ConstSharedPtr object_msg)
   // For testing purposes, normally pre-processing is done in the cuda side.
   // const auto agent_centric_histories = getAgentCentricHistories(histories);
   AgentData agent_data(histories, ego_index, target_indices, label_ids, relative_timestamps);
-  autoware::mtr::utils::print_agent_data(agent_data);
   std::vector<PredictedTrajectory> trajectories;
   if (!model_ptr_->doInference(agent_data, *polyline_data, trajectories)) {
     RCLCPP_WARN(get_logger(), "Inference failed");
@@ -387,8 +386,6 @@ std::vector<size_t> MTRNode::extractTargetAgent(const std::vector<AgentHistory> 
       tf2::doTransform(pose_in_map, pose_in_ego, *map2ego);
 
       const auto distance = std::hypot(pose_in_ego.pose.position.x, pose_in_ego.pose.position.y);
-      std::cerr << "object id and distance " << history.object_id() << " distaNce " << distance
-                << std::endl;
       index_distances.emplace_back(idx, distance);
     }
   }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -386,6 +386,8 @@ std::vector<size_t> MTRNode::extractTargetAgent(const std::vector<AgentHistory> 
       tf2::doTransform(pose_in_map, pose_in_ego, *map2ego);
 
       const auto distance = std::hypot(pose_in_ego.pose.position.x, pose_in_ego.pose.position.y);
+      std::cerr << "object id and distance " << history.object_id() << " distaNce " << distance
+                << std::endl;
       index_distances.emplace_back(idx, distance);
     }
   }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -364,7 +364,7 @@ std::vector<size_t> MTRNode::extractTargetAgent(const std::vector<AgentHistory> 
   std::vector<std::pair<size_t, double>> index_distances;
   for (size_t idx = 0; idx < histories.size(); ++idx) {
     const auto & history = histories.at(idx);
-    if (history.is_valid_latest() && history.object_id() != EGO_ID) {
+    if (history.is_valid_latest()) {
       const auto & state = history.get_latest_state();
       geometry_msgs::msg::PoseStamped pose_in_map;
       pose_in_map.pose.position.x = state.x();

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -376,7 +376,7 @@ std::vector<size_t> MTRNode::extractTargetAgent(const std::vector<AgentHistory> 
   for (size_t idx = 0; idx < histories.size(); ++idx) {
     const auto & history = histories.at(idx);
     if (history.is_valid_latest()) {
-      const auto & state = history.get_latest_state();
+      const auto state = history.get_latest_state();
       geometry_msgs::msg::PoseStamped pose_in_map;
       pose_in_map.pose.position.x = state.x();
       pose_in_map.pose.position.y = state.y();

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -336,7 +336,7 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     std::vector<float> host_buffer(
       num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim());
     cudaMemcpy(
-      host_buffer.data(), d_in_polyline_.get(),
+      host_buffer.data(), d_polyline_.get(),
       num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim() * sizeof(float),
       cudaMemcpyDeviceToHost);
     std::cerr << "polyline data has "
@@ -345,7 +345,7 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     size_t count = 0;
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "NaN found in d_in_polyline_ for element" << count++ << std::endl;
+        std::cerr << "NaN found in d_polyline_ for element" << count++ << std::endl;
         if (!std::isnan(val)) {
           std::cerr << "high value " << val << std::endl;
         }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -323,32 +323,32 @@ bool TrtMTR::postProcess(
         std::cerr << "}\n";
       }
     }
-
-    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
-
-    h_out_score_.clear();
-    h_out_trajectory_.clear();
-    h_out_score_.resize(num_target_ * num_mode_);
-    h_out_trajectory_.resize(num_target_ * num_mode_ * num_future_ * PredictedStateDim);
-
-    CHECK_CUDA_ERROR(cudaMemcpy(
-      h_out_score_.data(), d_out_score_.get(), sizeof(float) * num_target_ * num_mode_,
-      cudaMemcpyDeviceToHost));
-    CHECK_CUDA_ERROR(cudaMemcpy(
-      h_out_trajectory_.data(), d_out_trajectory_.get(),
-      sizeof(float) * num_target_ * num_mode_ * num_future_ * PredictedStateDim,
-      cudaMemcpyDeviceToHost));
-
-    trajectories.clear();
-    trajectories.reserve(num_target_);
-    for (auto b = 0; b < num_target_; ++b) {
-      const auto score_itr = h_out_score_.cbegin() + b * num_mode_;
-      const std::vector<double> scores(score_itr, score_itr + num_mode_);
-      const auto mode_itr =
-        h_out_trajectory_.cbegin() + b * num_mode_ * num_future_ * PredictedStateDim;
-      std::vector<double> modes(mode_itr, mode_itr + num_mode_ * num_future_ * PredictedStateDim);
-      trajectories.emplace_back(scores, modes, num_mode_, num_future_);
-    }
-    return true;
   }
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  h_out_score_.clear();
+  h_out_trajectory_.clear();
+  h_out_score_.resize(num_target_ * num_mode_);
+  h_out_trajectory_.resize(num_target_ * num_mode_ * num_future_ * PredictedStateDim);
+
+  CHECK_CUDA_ERROR(cudaMemcpy(
+    h_out_score_.data(), d_out_score_.get(), sizeof(float) * num_target_ * num_mode_,
+    cudaMemcpyDeviceToHost));
+  CHECK_CUDA_ERROR(cudaMemcpy(
+    h_out_trajectory_.data(), d_out_trajectory_.get(),
+    sizeof(float) * num_target_ * num_mode_ * num_future_ * PredictedStateDim,
+    cudaMemcpyDeviceToHost));
+
+  trajectories.clear();
+  trajectories.reserve(num_target_);
+  for (auto b = 0; b < num_target_; ++b) {
+    const auto score_itr = h_out_score_.cbegin() + b * num_mode_;
+    const std::vector<double> scores(score_itr, score_itr + num_mode_);
+    const auto mode_itr =
+      h_out_trajectory_.cbegin() + b * num_mode_ * num_future_ * PredictedStateDim;
+    std::vector<double> modes(mode_itr, mode_itr + num_mode_ * num_future_ * PredictedStateDim);
+    trajectories.emplace_back(scores, modes, num_mode_, num_future_);
+  }
+  return true;
+}
 }  // namespace autoware::mtr

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -225,18 +225,18 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     d_trajectory_.get(), d_in_trajectory_.get(), d_in_trajectory_mask_.get(), d_in_last_pos_.get(),
     stream_));
 
-  auto T = 11;
+  auto T = num_timestamp_;
   // auto D = 12;
   // auto C = 3;
 
-  auto B = 2;
-  auto N = 2;
+  auto B = num_target_;
+  auto N = num_agent_;
   {
     std::vector<float> host_buffer(num_target_ * num_agent_ * 3);
     cudaMemcpy(
       host_buffer.data(), d_in_last_pos_.get(), num_target_ * num_agent_ * 3 * sizeof(float),
       cudaMemcpyDeviceToHost);
-    std::cerr << "Preprocessed lat position \n";
+    std::cerr << "Preprocessed last position \n";
     std::vector<std::string> values{"x", "y", "z"};
     for (int b = 0; b < B; b++) {
       for (int n = 0; n < N; n++) {
@@ -275,6 +275,27 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
           std::cerr << "\n";
         }
         std::cerr << "}\n";
+      }
+    }
+  }
+  // Check for nan in d_in_trajectory_mask_
+  {
+    auto traj_mask = d_in_trajectory_mask_.get();
+    for (int i = 0; i < N * B * T; i++) {
+      if (traj_mask[i] == true) {
+        std::cerr << "True found in d_in_trajectory_mask_ at index " << i << std::endl;
+      }
+    }
+  }
+
+  {
+    std::vector<float> host_buffer(num_target_ * intention_point_.size());
+    cudaMemcpy(
+      host_buffer.data(), d_intention_point_.get(),
+      num_target_ * intention_point_.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    for (const auto & val : host_buffer) {
+      if (std::isnan(val)) {
+        std::cerr << "NaN found in d_intention_point_" << std::endl;
       }
     }
   }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -295,31 +295,60 @@ bool TrtMTR::postProcess(
     num_target_, num_mode_, num_future_, agent_data.state_dim(), d_target_state_.get(),
     PredictedStateDim, d_out_trajectory_.get(), stream_));
 
-  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+  {
+    auto B = num_target_;
+    auto M = num_mode_;
+    auto T = num_future_;
+    auto D = agent_data.state_dim();
+    std::vector<float> host_buffer(B * M * T * D);
 
-  h_out_score_.clear();
-  h_out_trajectory_.clear();
-  h_out_score_.resize(num_target_ * num_mode_);
-  h_out_trajectory_.resize(num_target_ * num_mode_ * num_future_ * PredictedStateDim);
+    // Step 2: Copy data from GPU to host
+    cudaMemcpy(
+      host_buffer.data(), d_in_trajectory_.get(), B * M * T * D * sizeof(float),
+      cudaMemcpyDeviceToHost);
 
-  CHECK_CUDA_ERROR(cudaMemcpy(
-    h_out_score_.data(), d_out_score_.get(), sizeof(float) * num_target_ * num_mode_,
-    cudaMemcpyDeviceToHost));
-  CHECK_CUDA_ERROR(cudaMemcpy(
-    h_out_trajectory_.data(), d_out_trajectory_.get(),
-    sizeof(float) * num_target_ * num_mode_ * num_future_ * PredictedStateDim,
-    cudaMemcpyDeviceToHost));
+    std::cerr << "Preprocessed output \n";
+    std::vector<std::string> values{"x", "y", "xmean", "ymean", "std_dev", "vx", "vy"};
+    for (int b = 0; b < B; b++) {
+      for (int m = 0; m < M; m++) {
+        std::cerr << "{b: " << b;
+        std::cerr << ",m: " << m << ": \n";
+        for (int t = 0; t < T; t++) {
+          for (size_t i = 0; i < D; ++i) {
+            std::cerr << values[i] << ": " << host_buffer[b * M * T * D + (m * T + t) * D + i]
+                      << ",";
+          }
+          std::cerr << "\n";
+        }
+        std::cerr << "}\n";
+      }
+    }
 
-  trajectories.clear();
-  trajectories.reserve(num_target_);
-  for (auto b = 0; b < num_target_; ++b) {
-    const auto score_itr = h_out_score_.cbegin() + b * num_mode_;
-    const std::vector<double> scores(score_itr, score_itr + num_mode_);
-    const auto mode_itr =
-      h_out_trajectory_.cbegin() + b * num_mode_ * num_future_ * PredictedStateDim;
-    std::vector<double> modes(mode_itr, mode_itr + num_mode_ * num_future_ * PredictedStateDim);
-    trajectories.emplace_back(scores, modes, num_mode_, num_future_);
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+    h_out_score_.clear();
+    h_out_trajectory_.clear();
+    h_out_score_.resize(num_target_ * num_mode_);
+    h_out_trajectory_.resize(num_target_ * num_mode_ * num_future_ * PredictedStateDim);
+
+    CHECK_CUDA_ERROR(cudaMemcpy(
+      h_out_score_.data(), d_out_score_.get(), sizeof(float) * num_target_ * num_mode_,
+      cudaMemcpyDeviceToHost));
+    CHECK_CUDA_ERROR(cudaMemcpy(
+      h_out_trajectory_.data(), d_out_trajectory_.get(),
+      sizeof(float) * num_target_ * num_mode_ * num_future_ * PredictedStateDim,
+      cudaMemcpyDeviceToHost));
+
+    trajectories.clear();
+    trajectories.reserve(num_target_);
+    for (auto b = 0; b < num_target_; ++b) {
+      const auto score_itr = h_out_score_.cbegin() + b * num_mode_;
+      const std::vector<double> scores(score_itr, score_itr + num_mode_);
+      const auto mode_itr =
+        h_out_trajectory_.cbegin() + b * num_mode_ * num_future_ * PredictedStateDim;
+      std::vector<double> modes(mode_itr, mode_itr + num_mode_ * num_future_ * PredictedStateDim);
+      trajectories.emplace_back(scores, modes, num_mode_, num_future_);
+    }
+    return true;
   }
-  return true;
-}
 }  // namespace autoware::mtr

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -265,10 +265,13 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (int b = 0; b < B; b++) {
       for (int n = 0; n < N; n++) {
         std::cerr << "{b: " << b;
-        std::cerr << ",n: " << n << ": ";
-        for (int i = 0; i < 29; ++i) {
-          std::cerr << values[i] << ": " << host_buffer[b * N * T * 29 + (n * T + T - 1) * 29 + i]
-                    << ",";
+        std::cerr << ",n: " << n << ": \n";
+        for (int t = 0; t < T; ++t) {
+          for (int i = 0; i < 29; ++i) {
+            std::cerr << values[i] << ": " << host_buffer[b * N * T * 29 + (n * T + t) * 29 + i]
+                      << ",";
+          }
+          std::cerr << "\n";
         }
         std::cerr << "}\n";
       }
@@ -296,39 +299,40 @@ bool TrtMTR::postProcess(
     num_target_, num_mode_, num_future_, agent_data.state_dim(), d_target_state_.get(),
     PredictedStateDim, d_out_trajectory_.get(), stream_));
 
-  {
-    auto B = num_target_;
-    auto M = num_mode_;
-    auto T = num_future_;
-    auto D = agent_data.state_dim();
-    std::vector<float> host_buffer(B * M * T * D);
+  // {
+  //   auto B = num_target_;
+  //   auto M = num_mode_;
+  //   auto T = num_future_;
+  //   auto D = agent_data.state_dim();
+  //   std::vector<float> host_buffer(B * M * T * D);
 
-    // Step 2: Copy data from GPU to host
-    cudaMemcpy(
-      host_buffer.data(), d_out_trajectory_.get(),
-      num_target_ * num_mode_ * num_future_ * PredictedStateDim * sizeof(float),
-      cudaMemcpyDeviceToHost);
+  //   // Step 2: Copy data from GPU to host
+  //   cudaMemcpy(
+  //     host_buffer.data(), d_out_trajectory_.get(),
+  //     num_target_ * num_mode_ * num_future_ * PredictedStateDim * sizeof(float),
+  //     cudaMemcpyDeviceToHost);
 
-    std::cerr << "Postprocessed output \n";
-    std::vector<std::string> values{"x", "y", "xmean", "ymean", "std_dev", "vx", "vy"};
-    for (int b = 0; b < B; b++) {
-      for (int m = 0; m < M; m++) {
-        std::cerr << "{b: " << b;
-        std::cerr << ",m: " << m << "\n";
-        for (size_t d = 0; d < D; ++d) {
-          auto idx = b * M * T * D + m * T * D + d;
-          auto value = host_buffer[idx];
-          if (std::isnan(value)) {
-            std::cerr << "NAN detected\n";
-            break;
-          }
-          std::cerr << values[d] << ": " << value << ",";
-        }
+  //   std::cerr << "Postprocessed output \n";
+  //   std::vector<std::string> values{"x", "y", "xmean", "ymean", "std_dev", "vx", "vy"};
+  //   for (int b = 0; b < B; b++) {
+  //     for (int m = 0; m < M; m++) {
+  //       std::cerr << "{b: " << b;
+  //       std::cerr << ",m: " << m << "\n";
+  //       for (size_t d = 0; d < D; ++d) {
+  //         auto idx = b * M * T * D + m * T * D + d;
+  //         std::cerr << "idx " << idx << "\n";
+  //         auto value = host_buffer[idx];
+  //         if (std::isnan(value)) {
+  //           std::cerr << "NAN detected\n";
+  //           break;
+  //         }
+  //         std::cerr << values[d] << ": " << value << ",";
+  //       }
 
-        std::cerr << "}\n";
-      }
-    }
-  }
+  //       std::cerr << "}\n";
+  //     }
+  //   }
+  // }
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 
   h_out_score_.clear();
@@ -346,12 +350,27 @@ bool TrtMTR::postProcess(
 
   trajectories.clear();
   trajectories.reserve(num_target_);
+  std::vector<std::string> values{"x", "y", "xmean", "ymean", "std_dev", "vx", "vy"};
+
   for (auto b = 0; b < num_target_; ++b) {
     const auto score_itr = h_out_score_.cbegin() + b * num_mode_;
     const std::vector<double> scores(score_itr, score_itr + num_mode_);
     const auto mode_itr =
       h_out_trajectory_.cbegin() + b * num_mode_ * num_future_ * PredictedStateDim;
     std::vector<double> modes(mode_itr, mode_itr + num_mode_ * num_future_ * PredictedStateDim);
+    std::cerr << "Target " << b << "\n";
+    for (size_t i = 0; i < static_cast<size_t>(num_mode_); i++) {
+      std::cerr << "Mode " << i << "\n";
+      for (size_t j = 0; j < static_cast<size_t>(num_future_); j++) {
+        std::cerr << "Step " << j << "\n";
+        for (size_t k = 0; k < PredictedStateDim; k++) {
+          std::cerr << values[k] << ": "
+                    << modes[i * num_future_ * PredictedStateDim + j * PredictedStateDim + k]
+                    << ",";
+        }
+        std::cerr << "\n";
+      }
+    }
     trajectories.emplace_back(scores, modes, num_mode_, num_future_);
   }
   return true;

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -292,21 +292,21 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
   }
 
   // // Check for NaN or invalid values in d_in_polyline_center_
-  // {
-  //   std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
-  //   cudaMemcpy(
-  //     host_buffer.data(), d_in_polyline_center_.get(),
-  //     num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
+  {
+    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
+    cudaMemcpy(
+      host_buffer.data(), d_in_polyline_center_.get(),
+      num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
 
-  //   for (const auto & val : host_buffer) {
-  //     if (std::isnan(val) || std::abs(val) > 1000) {
-  //       std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
-  //       if (!std::isnan(val)) {
-  //         std::cerr << "high value " << val << std::endl;
-  //       }
-  //     }
-  //   }
-  // }
+    for (const auto & val : host_buffer) {
+      if (std::isnan(val) || std::abs(val) > 1000) {
+        std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
+        if (!std::isnan(val)) {
+          std::cerr << "high value " << val << std::endl;
+        }
+      }
+    }
+  }
 
   // Check for NaN or invalid values in d_in_polyline_
   {

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -279,12 +279,14 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     }
   }
   if (max_num_polyline_ < num_polyline_) {
+    std::cerr << "Using topk\n";
     CHECK_CUDA_ERROR(polylinePreprocessWithTopkLauncher(
       max_num_polyline_, num_polyline_, num_point_, polyline_data.state_dim(), d_polyline_.get(),
       num_target_, agent_data.state_dim(), d_target_state_.get(), d_tmp_polyline_.get(),
       d_tmp_polyline_mask_.get(), d_tmp_distance_.get(), d_in_polyline_.get(),
       d_in_polyline_mask_.get(), d_in_polyline_center_.get(), stream_));
   } else {
+    std::cerr << "Using normal\n";
     CHECK_CUDA_ERROR(polylinePreprocessLauncher(
       num_polyline_, num_point_, polyline_data.state_dim(), d_polyline_.get(), num_target_,
       agent_data.state_dim(), d_target_state_.get(), d_in_polyline_.get(),

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -314,38 +314,36 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
       d_in_polyline_mask_.get(), d_in_polyline_center_.get(), stream_));
   }
 
-  // // Check for NaN or invalid values in d_in_polyline_center_
-  {
-    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
-    cudaMemcpy(
-      host_buffer.data(), d_in_polyline_center_.get(),
-      num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
+  // // // Check for NaN or invalid values in d_in_polyline_center_
+  // {
+  //   std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
+  //   cudaMemcpy(
+  //     host_buffer.data(), d_in_polyline_center_.get(),
+  //     num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
 
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
-        if (!std::isnan(val)) {
-          std::cerr << "high value " << val << std::endl;
-        }
-      }
-    }
-  }
+  //   for (const auto & val : host_buffer) {
+  //     if (std::isnan(val) || std::abs(val) > 1000) {
+  //       std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
+  //       if (!std::isnan(val)) {
+  //         std::cerr << "high value " << val << std::endl;
+  //       }
+  //     }
+  //   }
+  // }
 
   // Check for NaN or invalid values in d_in_polyline_
   {
-    std::vector<float> host_buffer(
-      num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim());
+    std::vector<float> host_buffer(num_target_ * num_polyline_ * num_point_ * num_point_attr_);
     cudaMemcpy(
-      host_buffer.data(), d_polyline_.get(),
-      num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim() * sizeof(float),
+      host_buffer.data(), d_tmp_polyline_.get(),
+      num_target_ * num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
       cudaMemcpyDeviceToHost);
-    std::cerr << "polyline data has "
-              << num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim()
+    std::cerr << "polyline data has " << num_target_ * num_polyline_ * num_point_ * num_point_attr_
               << " elements\n";
     size_t count = 0;
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "NaN found in d_polyline_ for element" << count++ << std::endl;
+        std::cerr << "NaN found in d_tmp_polyline_ for element" << count++ << std::endl;
         if (!std::isnan(val)) {
           std::cerr << "high value " << val << std::endl;
         }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -304,7 +304,8 @@ bool TrtMTR::postProcess(
 
     // Step 2: Copy data from GPU to host
     cudaMemcpy(
-      host_buffer.data(), d_out_trajectory_.get(), B * M * T * D * sizeof(float),
+      host_buffer.data(), d_out_trajectory_.get(),
+      num_target_ * num_mode_ * num_future_ * PredictedStateDim * sizeof(float),
       cudaMemcpyDeviceToHost);
 
     std::cerr << "Postprocessed output \n";
@@ -313,14 +314,11 @@ bool TrtMTR::postProcess(
       for (int m = 0; m < M; m++) {
         std::cerr << "{b: " << b;
         std::cerr << ",m: " << m << "\n";
-        for (int t = 0; t < T; t = t + 10) {
-          std::cerr << ",t: " << t << ": ";
-          for (size_t i = 0; i < D; ++i) {
-            std::cerr << values[i] << ": " << host_buffer[b * M * T * D + (m * T + t) * D + i]
-                      << ",";
-          }
-          std::cerr << "\n";
+        for (size_t d = 0; d < D; ++d) {
+          std::cerr << values[d] << ": " << host_buffer[b * M * T * D + (m * T + T - 1) * D + d]
+                    << ",";
         }
+
         std::cerr << "}\n";
       }
     }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -304,16 +304,16 @@ bool TrtMTR::postProcess(
 
     // Step 2: Copy data from GPU to host
     cudaMemcpy(
-      host_buffer.data(), d_in_trajectory_.get(), B * M * T * D * sizeof(float),
+      host_buffer.data(), d_out_trajectory_.get(), B * M * T * D * sizeof(float),
       cudaMemcpyDeviceToHost);
 
-    std::cerr << "Preprocessed output \n";
+    std::cerr << "Postprocessed output \n";
     std::vector<std::string> values{"x", "y", "xmean", "ymean", "std_dev", "vx", "vy"};
     for (int b = 0; b < B; b++) {
       for (int m = 0; m < M; m++) {
         std::cerr << "{b: " << b;
         std::cerr << ",m: " << m << ": \n";
-        for (int t = 0; t < T; t++) {
+        for (int t = 0; t < T; ++t) {
           for (size_t i = 0; i < D; ++i) {
             std::cerr << values[i] << ": " << host_buffer[b * M * T * D + (m * T + t) * D + i]
                       << ",";

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -312,8 +312,9 @@ bool TrtMTR::postProcess(
     for (int b = 0; b < B; b++) {
       for (int m = 0; m < M; m++) {
         std::cerr << "{b: " << b;
-        std::cerr << ",m: " << m << ": \n";
-        for (int t = 0; t < T; ++t) {
+        std::cerr << ",m: " << m << "\n";
+        for (int t = 0; t < T; t = t + 10) {
+          std::cerr << ",t: " << t << ": ";
           for (size_t i = 0; i < D; ++i) {
             std::cerr << values[i] << ": " << host_buffer[b * M * T * D + (m * T + t) * D + i]
                       << ",";

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -244,7 +244,7 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
   for (int b = 0; b < B; b++) {
     for (int n = 0; n < N; n++) {
       std::cerr << "{b: " << b;
-      std::cerr << ",n: " << b << ": ";
+      std::cerr << ",n: " << n << ": ";
       for (int i = 0; i < 29; ++i) {
         std::cerr << values[i] << ": " << host_buffer[b * N * T * 29 + (n * T + T - 1) * 29 + i]
                   << ",";

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -298,7 +298,6 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {
         std::cerr << "Invalid value found in d_in_polyline_center_" << std::endl;
-        return false;
       }
     }
   }
@@ -313,7 +312,6 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {
         std::cerr << "Invalid value found in d_in_polyline_" << std::endl;
-        return false;
       }
     }
   }
@@ -327,7 +325,6 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {
         std::cerr << "Invalid value found in d_intention_point_" << std::endl;
-        return false;
       }
     }
   }
@@ -340,7 +337,9 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {
         std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
-        return false;
+        if (!std::isnan(val)) {
+          std::cerr << "high value " << val << std::endl;
+        }
       }
     }
   }
@@ -355,7 +354,6 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (const auto & val : host_buffer) {
       if (std::isnan(val)) {
         std::cerr << "NaN found in d_in_polyline_" << std::endl;
-        return false;
       }
     }
   }
@@ -369,7 +367,6 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (const auto & val : host_buffer) {
       if (std::isnan(val)) {
         std::cerr << "NaN found in d_intention_point_" << std::endl;
-        return false;
       }
     }
   }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -229,27 +229,48 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
 
   auto B = 2;
   auto N = 2;
-
-  std::vector<float> host_buffer(N * B * T * 29);
-
-  // Step 2: Copy data from GPU to host
-  cudaMemcpy(
-    host_buffer.data(), d_in_trajectory_.get(), N * B * T * 29 * sizeof(float),
-    cudaMemcpyDeviceToHost);
-
-  std::cerr << "Preprocessed output \n";
-  std::vector<std::string> values{"x",  "y",   "z",   "L",    "W",    "H",  "O0", "O1", "O2", "O3",
-                                  "O4", "T0",  "T1",  "T2",   "T3",   "T4", "T5", "T6", "T7", "T8",
-                                  "T9", "T10", "T11", "Yaw0", "Yaw1", "Vx", "Vy", "Ax", "Ay"};
-  for (int b = 0; b < B; b++) {
-    for (int n = 0; n < N; n++) {
-      std::cerr << "{b: " << b;
-      std::cerr << ",n: " << n << ": ";
-      for (int i = 0; i < 29; ++i) {
-        std::cerr << values[i] << ": " << host_buffer[b * N * T * 29 + (n * T + T - 1) * 29 + i]
-                  << ",";
+  {
+    std::vector<float> host_buffer(num_target_ * num_agent_ * 3);
+    cudaMemcpy(
+      host_buffer.data(), d_in_last_pos_.get(), num_target_ * num_agent_ * 3 * sizeof(float),
+      cudaMemcpyDeviceToHost);
+    std::cerr << "Preprocessed lat position \n";
+    std::vector<std::string> values{"x", "y", "z"};
+    for (int b = 0; b < B; b++) {
+      for (int n = 0; n < N; n++) {
+        std::cerr << "{b: " << b;
+        std::cerr << ",n: " << n << ": ";
+        for (int i = 0; i < 3; ++i) {
+          std::cerr << values[i] << ": " << host_buffer[b * N * 3 + n * 3 + i] << ",";
+        }
+        std::cerr << "}\n";
       }
-      std::cerr << "}\n";
+    }
+  }
+
+  {
+    std::vector<float> host_buffer(N * B * T * 29);
+
+    // Step 2: Copy data from GPU to host
+    cudaMemcpy(
+      host_buffer.data(), d_in_trajectory_.get(), N * B * T * 29 * sizeof(float),
+      cudaMemcpyDeviceToHost);
+
+    std::cerr << "Preprocessed output \n";
+    std::vector<std::string> values{"x",    "y",  "z",  "L",  "W",  "H",   "O0",  "O1",
+                                    "O2",   "O3", "O4", "T0", "T1", "T2",  "T3",  "T4",
+                                    "T5",   "T6", "T7", "T8", "T9", "T10", "T11", "Yaw0",
+                                    "Yaw1", "Vx", "Vy", "Ax", "Ay"};
+    for (int b = 0; b < B; b++) {
+      for (int n = 0; n < N; n++) {
+        std::cerr << "{b: " << b;
+        std::cerr << ",n: " << n << ": ";
+        for (int i = 0; i < 29; ++i) {
+          std::cerr << values[i] << ": " << host_buffer[b * N * T * 29 + (n * T + T - 1) * 29 + i]
+                    << ",";
+        }
+        std::cerr << "}\n";
+      }
     }
   }
   if (max_num_polyline_ < num_polyline_) {

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -300,26 +300,6 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     }
   }
 
-  // Check for NaN or invalid values in d_in_polyline_
-  {
-    std::vector<float> host_buffer(num_target_ * num_polyline_ * num_point_ * num_point_attr_);
-    cudaMemcpy(
-      host_buffer.data(), d_tmp_polyline_.get(),
-      num_target_ * num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
-      cudaMemcpyDeviceToHost);
-    std::cerr << "polyline data has " << num_target_ * num_polyline_ * num_point_ * num_point_attr_
-              << " elements\n";
-    size_t count = 0;
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "NaN found in d_tmp_polyline_ for element" << count++ << std::endl;
-        if (!std::isnan(val)) {
-          std::cerr << "high value " << val << std::endl;
-        }
-      }
-    }
-  }
-
   if (max_num_polyline_ < num_polyline_) {
     std::cerr << "Using topk\n";
     CHECK_CUDA_ERROR(polylinePreprocessWithTopkLauncher(
@@ -333,6 +313,26 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
       num_polyline_, num_point_, polyline_data.state_dim(), d_polyline_.get(), num_target_,
       agent_data.state_dim(), d_target_state_.get(), d_in_polyline_.get(),
       d_in_polyline_mask_.get(), d_in_polyline_center_.get(), stream_));
+  }
+
+  // Check for NaN or invalid values in d_in_polyline_
+  {
+    std::vector<float> host_buffer(num_target_ * num_polyline_ * num_point_ * num_point_attr_);
+    cudaMemcpy(
+      host_buffer.data(), d_tmp_polyline_.get(),
+      num_target_ * num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
+      cudaMemcpyDeviceToHost);
+    std::cerr << "polyline data has " << num_target_ * num_polyline_ * num_point_ * num_point_attr_
+              << " elements\n";
+    size_t count = 0;
+    for (const auto & val : host_buffer) {
+      if ((std::isnan(val) || std::abs(val) > 1000) && count < 10) {
+        std::cerr << "NaN found in d_tmp_polyline_ for element" << count++ << std::endl;
+        if (!std::isnan(val)) {
+          std::cerr << "high value " << val << std::endl;
+        }
+      }
+    }
   }
 
   // // // Check for NaN or invalid values in d_in_polyline_center_

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -21,6 +21,7 @@
 #include "preprocess/agent_preprocess_kernel.cuh"
 #include "preprocess/polyline_preprocess_kernel.cuh"
 
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -315,8 +316,13 @@ bool TrtMTR::postProcess(
         std::cerr << "{b: " << b;
         std::cerr << ",m: " << m << "\n";
         for (size_t d = 0; d < D; ++d) {
-          std::cerr << values[d] << ": " << host_buffer[b * M * T * D + (m * T + T - 1) * D + d]
-                    << ",";
+          auto idx = b * M * T * D + m * T * D + d;
+          auto value = host_buffer[idx];
+          if (std::isnan(value)) {
+            std::cerr << "NAN detected\n";
+            break;
+          }
+          std::cerr << values[d] << ": " << value << ",";
         }
 
         std::cerr << "}\n";

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -223,6 +223,35 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     d_trajectory_.get(), d_in_trajectory_.get(), d_in_trajectory_mask_.get(), d_in_last_pos_.get(),
     stream_));
 
+  auto T = 11;
+  // auto D = 12;
+  // auto C = 3;
+
+  auto B = 2;
+  auto N = 2;
+
+  std::vector<float> host_buffer(N * B * T * 29);
+
+  // Step 2: Copy data from GPU to host
+  cudaMemcpy(
+    host_buffer.data(), d_in_trajectory_.get(), N * B * T * 29 * sizeof(float),
+    cudaMemcpyDeviceToHost);
+
+  std::cerr << "Preprocessed output \n";
+  std::vector<std::string> values{"x",  "y",   "z",   "L",    "W",    "H",  "O0", "O1", "O2", "O3",
+                                  "O4", "T0",  "T1",  "T2",   "T3",   "T4", "T5", "T6", "T7", "T8",
+                                  "T9", "T10", "T11", "Yaw0", "Yaw1", "Vx", "Vy", "Ax", "Ay"};
+  for (int b = 0; b < B; b++) {
+    for (int n = 0; n < N; n++) {
+      std::cerr << "{b: " << b;
+      std::cerr << ",n: " << b << ": ";
+      for (int i = 0; i < 29; ++i) {
+        std::cerr << values[i] << ": " << host_buffer[b * N * T * 29 + (n * T + T - 1) * 29 + i]
+                  << ",";
+      }
+      std::cerr << "}\n";
+    }
+  }
   if (max_num_polyline_ < num_polyline_) {
     CHECK_CUDA_ERROR(polylinePreprocessWithTopkLauncher(
       max_num_polyline_, num_polyline_, num_point_, polyline_data.state_dim(), d_polyline_.get(),

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -22,6 +22,7 @@
 #include "preprocess/polyline_preprocess_kernel.cuh"
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -289,18 +290,23 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
       agent_data.state_dim(), d_target_state_.get(), d_in_polyline_.get(),
       d_in_polyline_mask_.get(), d_in_polyline_center_.get(), stream_));
   }
-  // Check for NaN or invalid values in d_in_polyline_center_
-  {
-    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
-    cudaMemcpy(
-      host_buffer.data(), d_in_polyline_center_.get(),
-      num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "Invalid value found in d_in_polyline_center_" << std::endl;
-      }
-    }
-  }
+
+  // // Check for NaN or invalid values in d_in_polyline_center_
+  // {
+  //   std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
+  //   cudaMemcpy(
+  //     host_buffer.data(), d_in_polyline_center_.get(),
+  //     num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
+
+  //   for (const auto & val : host_buffer) {
+  //     if (std::isnan(val) || std::abs(val) > 1000) {
+  //       std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
+  //       if (!std::isnan(val)) {
+  //         std::cerr << "high value " << val << std::endl;
+  //       }
+  //     }
+  //   }
+  // }
 
   // Check for NaN or invalid values in d_in_polyline_
   {
@@ -309,54 +315,12 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
       host_buffer.data(), d_in_polyline_.get(),
       num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
       cudaMemcpyDeviceToHost);
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "Invalid value found in d_in_polyline_" << std::endl;
-      }
-    }
-  }
-
-  // Check for NaN or invalid values in d_intention_point_
-  {
-    std::vector<float> host_buffer(num_target_ * intention_point_.size());
-    cudaMemcpy(
-      host_buffer.data(), d_intention_point_.get(),
-      num_target_ * intention_point_.size() * sizeof(float), cudaMemcpyDeviceToHost);
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "Invalid value found in d_intention_point_" << std::endl;
-        if (!std::isnan(val)) {
-          std::cerr << "high value " << val << std::endl;
-        }
-      }
-    }
-  }
-  // Check for NaN or invalid values in d_in_polyline_center_
-  {
-    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
-    cudaMemcpy(
-      host_buffer.data(), d_in_polyline_center_.get(),
-      num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
-        if (!std::isnan(val)) {
-          std::cerr << "high value " << val << std::endl;
-        }
-      }
-    }
-  }
-
-  // Check for NaN or invalid values in d_in_polyline_
-  {
-    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * num_point_ * num_point_attr_);
-    cudaMemcpy(
-      host_buffer.data(), d_in_polyline_.get(),
-      num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
-      cudaMemcpyDeviceToHost);
+    std::cerr << "polyline data has "
+              << num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ << " elements\n";
+    size_t count = 0;
     for (const auto & val : host_buffer) {
       if (std::isnan(val)) {
-        std::cerr << "NaN found in d_in_polyline_" << std::endl;
+        std::cerr << "NaN found in d_in_polyline_ for element" << count++ << std::endl;
       }
     }
   }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -325,6 +325,9 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {
         std::cerr << "Invalid value found in d_intention_point_" << std::endl;
+        if (!std::isnan(val)) {
+          std::cerr << "high value " << val << std::endl;
+        }
       }
     }
   }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -225,144 +225,17 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     d_trajectory_.get(), d_in_trajectory_.get(), d_in_trajectory_mask_.get(), d_in_last_pos_.get(),
     stream_));
 
-  auto T = num_timestamp_;
-  // auto D = 12;
-  // auto C = 3;
-
-  auto B = num_target_;
-  auto N = num_agent_;
-  {
-    std::vector<float> host_buffer(num_target_ * num_agent_ * 3);
-    cudaMemcpy(
-      host_buffer.data(), d_in_last_pos_.get(), num_target_ * num_agent_ * 3 * sizeof(float),
-      cudaMemcpyDeviceToHost);
-    std::cerr << "Preprocessed last position \n";
-    std::vector<std::string> values{"x", "y", "z"};
-    for (int b = 0; b < B; b++) {
-      for (int n = 0; n < N; n++) {
-        std::cerr << "{b: " << b;
-        std::cerr << ",n: " << n << ": ";
-        for (int i = 0; i < 3; ++i) {
-          std::cerr << values[i] << ": " << host_buffer[b * N * 3 + n * 3 + i] << ",";
-        }
-        std::cerr << "}\n";
-      }
-    }
-  }
-
-  {
-    std::vector<float> host_buffer(N * B * T * 29);
-
-    // Step 2: Copy data from GPU to host
-    cudaMemcpy(
-      host_buffer.data(), d_in_trajectory_.get(), N * B * T * 29 * sizeof(float),
-      cudaMemcpyDeviceToHost);
-
-    std::cerr << "Preprocessed output \n";
-    std::vector<std::string> values{"x",    "y",  "z",  "L",  "W",  "H",   "O0",  "O1",
-                                    "O2",   "O3", "O4", "T0", "T1", "T2",  "T3",  "T4",
-                                    "T5",   "T6", "T7", "T8", "T9", "T10", "T11", "Yaw0",
-                                    "Yaw1", "Vx", "Vy", "Ax", "Ay"};
-    for (int b = 0; b < B; b++) {
-      for (int n = 0; n < N; n++) {
-        std::cerr << "{b: " << b;
-        std::cerr << ",n: " << n << ": \n";
-        for (int t = 0; t < T; ++t) {
-          for (int i = 0; i < 29; ++i) {
-            std::cerr << values[i] << ": " << host_buffer[b * N * T * 29 + (n * T + t) * 29 + i]
-                      << ",";
-          }
-          std::cerr << "\n";
-        }
-        std::cerr << "}\n";
-      }
-    }
-  }
-  // Check for nan in d_in_trajectory_mask_
-  // {
-  //   auto traj_mask = d_in_trajectory_mask_.get();
-  //   for (int i = 0; i < N * B * T; i++) {
-  //     if (traj_mask[i] == true) {
-  //       std::cerr << "True found in d_in_trajectory_mask_ at index " << i << std::endl;
-  //     }
-  //   }
-  // }
-
-  {
-    std::vector<float> host_buffer(num_target_ * intention_point_.size());
-    cudaMemcpy(
-      host_buffer.data(), d_intention_point_.get(),
-      num_target_ * intention_point_.size() * sizeof(float), cudaMemcpyDeviceToHost);
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val)) {
-        std::cerr << "NaN found in d_intention_point_" << std::endl;
-      }
-    }
-  }
-
   if (max_num_polyline_ < num_polyline_) {
-    std::cerr << "Using topk\n";
     CHECK_CUDA_ERROR(polylinePreprocessWithTopkLauncher(
       max_num_polyline_, num_polyline_, num_point_, polyline_data.state_dim(), d_polyline_.get(),
       num_target_, agent_data.state_dim(), d_target_state_.get(), d_tmp_polyline_.get(),
       d_tmp_polyline_mask_.get(), d_tmp_distance_.get(), d_in_polyline_.get(),
       d_in_polyline_mask_.get(), d_in_polyline_center_.get(), stream_));
   } else {
-    std::cerr << "Using normal\n";
     CHECK_CUDA_ERROR(polylinePreprocessLauncher(
       num_polyline_, num_point_, polyline_data.state_dim(), d_polyline_.get(), num_target_,
       agent_data.state_dim(), d_target_state_.get(), d_in_polyline_.get(),
       d_in_polyline_mask_.get(), d_in_polyline_center_.get(), stream_));
-  }
-
-  // Check for NaN or invalid values in d_in_polyline_
-  {
-    std::vector<float> host_buffer(num_target_ * num_polyline_ * num_point_ * num_point_attr_);
-    cudaMemcpy(
-      host_buffer.data(), d_tmp_polyline_.get(),
-      num_target_ * num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
-      cudaMemcpyDeviceToHost);
-    std::cerr << "polyline data has " << num_target_ * num_polyline_ * num_point_ * num_point_attr_
-              << " elements\n";
-    size_t count = 0;
-    for (const auto & val : host_buffer) {
-      if ((std::isnan(val) || std::abs(val) > 1000) && count < 10) {
-        std::cerr << "NaN found in d_tmp_polyline_ for element" << count++ << std::endl;
-        if (!std::isnan(val)) {
-          std::cerr << "high value " << val << std::endl;
-        }
-      }
-    }
-  }
-
-  // // // Check for NaN or invalid values in d_in_polyline_center_
-  // {
-  //   std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
-  //   cudaMemcpy(
-  //     host_buffer.data(), d_in_polyline_center_.get(),
-  //     num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
-
-  //   for (const auto & val : host_buffer) {
-  //     if (std::isnan(val) || std::abs(val) > 1000) {
-  //       std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
-  //       if (!std::isnan(val)) {
-  //         std::cerr << "high value " << val << std::endl;
-  //       }
-  //     }
-  //   }
-  // }
-
-  // Check for NaN or invalid values in d_intention_point_
-  {
-    std::vector<float> host_buffer(num_target_ * intention_point_.size());
-    cudaMemcpy(
-      host_buffer.data(), d_intention_point_.get(),
-      num_target_ * intention_point_.size() * sizeof(float), cudaMemcpyDeviceToHost);
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val)) {
-        std::cerr << "NaN found in d_intention_point_" << std::endl;
-      }
-    }
   }
   return true;
 }
@@ -399,19 +272,6 @@ bool TrtMTR::postProcess(
     const auto mode_itr =
       h_out_trajectory_.cbegin() + b * num_mode_ * num_future_ * PredictedStateDim;
     std::vector<double> modes(mode_itr, mode_itr + num_mode_ * num_future_ * PredictedStateDim);
-    std::cerr << "Target " << b << "\n";
-    for (size_t i = 0; i < static_cast<size_t>(num_mode_); i++) {
-      std::cerr << "Mode " << i << "\n";
-      for (size_t j = 0; j < static_cast<size_t>(num_future_); j++) {
-        std::cerr << "Step " << j << "\n";
-        for (size_t k = 0; k < PredictedStateDim; k++) {
-          std::cerr << values[k] << ": "
-                    << modes[i * num_future_ * PredictedStateDim + j * PredictedStateDim + k]
-                    << ",";
-        }
-        std::cerr << "\n";
-      }
-    }
     trajectories.emplace_back(scores, modes, num_mode_, num_future_);
   }
   return true;

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -299,6 +299,27 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
       }
     }
   }
+
+  // Check for NaN or invalid values in d_in_polyline_
+  {
+    std::vector<float> host_buffer(num_target_ * num_polyline_ * num_point_ * num_point_attr_);
+    cudaMemcpy(
+      host_buffer.data(), d_tmp_polyline_.get(),
+      num_target_ * num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
+      cudaMemcpyDeviceToHost);
+    std::cerr << "polyline data has " << num_target_ * num_polyline_ * num_point_ * num_point_attr_
+              << " elements\n";
+    size_t count = 0;
+    for (const auto & val : host_buffer) {
+      if (std::isnan(val) || std::abs(val) > 1000) {
+        std::cerr << "NaN found in d_tmp_polyline_ for element" << count++ << std::endl;
+        if (!std::isnan(val)) {
+          std::cerr << "high value " << val << std::endl;
+        }
+      }
+    }
+  }
+
   if (max_num_polyline_ < num_polyline_) {
     std::cerr << "Using topk\n";
     CHECK_CUDA_ERROR(polylinePreprocessWithTopkLauncher(
@@ -330,26 +351,6 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
   //     }
   //   }
   // }
-
-  // Check for NaN or invalid values in d_in_polyline_
-  {
-    std::vector<float> host_buffer(num_target_ * num_polyline_ * num_point_ * num_point_attr_);
-    cudaMemcpy(
-      host_buffer.data(), d_tmp_polyline_.get(),
-      num_target_ * num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
-      cudaMemcpyDeviceToHost);
-    std::cerr << "polyline data has " << num_target_ * num_polyline_ * num_point_ * num_point_attr_
-              << " elements\n";
-    size_t count = 0;
-    for (const auto & val : host_buffer) {
-      if (std::isnan(val) || std::abs(val) > 1000) {
-        std::cerr << "NaN found in d_tmp_polyline_ for element" << count++ << std::endl;
-        if (!std::isnan(val)) {
-          std::cerr << "high value " << val << std::endl;
-        }
-      }
-    }
-  }
 
   // Check for NaN or invalid values in d_intention_point_
   {

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -264,7 +264,6 @@ bool TrtMTR::postProcess(
 
   trajectories.clear();
   trajectories.reserve(num_target_);
-  std::vector<std::string> values{"x", "y", "xmean", "ymean", "std_dev", "vx", "vy"};
 
   for (auto b = 0; b < num_target_; ++b) {
     const auto score_itr = h_out_score_.cbegin() + b * num_mode_;

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -264,7 +264,6 @@ bool TrtMTR::postProcess(
 
   trajectories.clear();
   trajectories.reserve(num_target_);
-
   for (auto b = 0; b < num_target_; ++b) {
     const auto score_itr = h_out_score_.cbegin() + b * num_mode_;
     const std::vector<double> scores(score_itr, score_itr + num_mode_);

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -333,13 +333,15 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
 
   // Check for NaN or invalid values in d_in_polyline_
   {
-    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * num_point_ * num_point_attr_);
+    std::vector<float> host_buffer(
+      num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim());
     cudaMemcpy(
       host_buffer.data(), d_in_polyline_.get(),
-      num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
+      num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim() * sizeof(float),
       cudaMemcpyDeviceToHost);
     std::cerr << "polyline data has "
-              << num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ << " elements\n";
+              << num_target_ * max_num_polyline_ * num_point_ * polyline_data.state_dim()
+              << " elements\n";
     size_t count = 0;
     for (const auto & val : host_buffer) {
       if (std::isnan(val) || std::abs(val) > 1000) {

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -342,8 +342,11 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
               << num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ << " elements\n";
     size_t count = 0;
     for (const auto & val : host_buffer) {
-      if (std::isnan(val)) {
+      if (std::isnan(val) || std::abs(val) > 1000) {
         std::cerr << "NaN found in d_in_polyline_ for element" << count++ << std::endl;
+        if (!std::isnan(val)) {
+          std::cerr << "high value " << val << std::endl;
+        }
       }
     }
   }

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -93,34 +93,76 @@ void TrtMTR::initCudaPtr(const AgentData & agent_data, const PolylineData & poly
 
   // source data
   d_target_index_ = cuda::make_unique<int[]>(num_target_);
+  cudaMemset(d_target_index_.get(), 0, num_target_ * sizeof(int));
+
   d_label_index_ = cuda::make_unique<int[]>(num_agent_);
+  cudaMemset(d_label_index_.get(), 0, num_agent_ * sizeof(int));
+
   d_timestamp_ = cuda::make_unique<float[]>(num_timestamp_);
+  cudaMemset(d_timestamp_.get(), 0.0, num_timestamp_ * sizeof(float));
+
   d_trajectory_ = cuda::make_unique<float[]>(agent_data.size());
+  cudaMemset(d_trajectory_.get(), 0.0, agent_data.size() * sizeof(float));
+
   d_target_state_ = cuda::make_unique<float[]>(num_target_ * agent_data.state_dim());
+  cudaMemset(d_target_state_.get(), 0.0, num_target_ * agent_data.state_dim() * sizeof(float));
+
   d_intention_point_ = cuda::make_unique<float[]>(num_target_ * intention_point_.size());
+  cudaMemset(d_intention_point_.get(), 0.0, num_target_ * intention_point_.size() * sizeof(float));
+
   d_polyline_ = cuda::make_unique<float[]>(polyline_data.size());
+  cudaMemset(d_polyline_.get(), 0.0, polyline_data.size() * sizeof(float));
 
   // preprocessed input
   d_in_trajectory_ =
     cuda::make_unique<float[]>(num_target_ * num_agent_ * num_timestamp_ * num_agent_attr_);
+  cudaMemset(
+    d_in_trajectory_.get(), 0.0,
+    num_target_ * num_agent_ * num_timestamp_ * num_agent_attr_ * sizeof(float));
   d_in_trajectory_mask_ = cuda::make_unique<bool[]>(num_target_ * num_agent_ * num_timestamp_);
+  cudaMemset(
+    d_in_trajectory_mask_.get(), false, num_target_ * num_agent_ * num_timestamp_ * sizeof(bool));
+
   d_in_last_pos_ = cuda::make_unique<float[]>(num_target_ * num_agent_ * 3);
+  cudaMemset(d_in_last_pos_.get(), 0.0, num_target_ * num_agent_ * 3 * sizeof(float));
+
   d_in_polyline_ =
     cuda::make_unique<float[]>(num_target_ * max_num_polyline_ * num_point_ * num_point_attr_);
+  cudaMemset(
+    d_in_polyline_.get(), 0.0,
+    num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ * sizeof(float));
+
   d_in_polyline_mask_ = cuda::make_unique<bool[]>(num_target_ * max_num_polyline_ * num_point_);
+  cudaMemset(
+    d_in_polyline_.get(), false, num_target_ * max_num_polyline_ * num_point_ * sizeof(bool));
+
   d_in_polyline_center_ = cuda::make_unique<float[]>(num_target_ * max_num_polyline_ * 3);
+  cudaMemset(d_in_polyline_.get(), 0.0, num_target_ * max_num_polyline_ * 3 * sizeof(float));
 
   if (max_num_polyline_ < num_polyline_) {
     d_tmp_polyline_ =
       cuda::make_unique<float[]>(num_target_ * num_polyline_ * num_point_ * num_point_attr_);
+    cudaMemset(
+      d_tmp_polyline_.get(), 0.0,
+      num_target_ * num_polyline_ * num_point_ * num_point_attr_ * sizeof(float));
+
     d_tmp_polyline_mask_ = cuda::make_unique<bool[]>(num_target_ * num_polyline_ * num_point_);
+    cudaMemset(
+      d_tmp_polyline_mask_.get(), false, num_target_ * num_polyline_ * num_point_ * sizeof(bool));
+
     d_tmp_distance_ = cuda::make_unique<float[]>(num_target_ * num_polyline_);
+    cudaMemset(d_tmp_distance_.get(), 0.0, num_target_ * num_polyline_ * sizeof(float));
   }
 
   // outputs
   d_out_score_ = cuda::make_unique<float[]>(num_target_ * num_mode_);
+  cudaMemset(d_out_score_.get(), 0.0, num_target_ * num_mode_ * sizeof(float));
+
   d_out_trajectory_ =
     cuda::make_unique<float[]>(num_target_ * num_mode_ * num_future_ * PredictedStateDim);
+  cudaMemset(
+    d_out_trajectory_.get(), 0.0,
+    num_target_ * num_mode_ * num_future_ * PredictedStateDim * sizeof(float));
 
   if (builder_->isDynamic()) {
     // trajectory: (B, N, T, Da)

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -279,14 +279,14 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
     }
   }
   // Check for nan in d_in_trajectory_mask_
-  {
-    auto traj_mask = d_in_trajectory_mask_.get();
-    for (int i = 0; i < N * B * T; i++) {
-      if (traj_mask[i] == true) {
-        std::cerr << "True found in d_in_trajectory_mask_ at index " << i << std::endl;
-      }
-    }
-  }
+  // {
+  //   auto traj_mask = d_in_trajectory_mask_.get();
+  //   for (int i = 0; i < N * B * T; i++) {
+  //     if (traj_mask[i] == true) {
+  //       std::cerr << "True found in d_in_trajectory_mask_ at index " << i << std::endl;
+  //     }
+  //   }
+  // }
 
   {
     std::vector<float> host_buffer(num_target_ * intention_point_.size());

--- a/src/trt_mtr.cpp
+++ b/src/trt_mtr.cpp
@@ -289,6 +289,49 @@ bool TrtMTR::preProcess(const AgentData & agent_data, const PolylineData & polyl
       agent_data.state_dim(), d_target_state_.get(), d_in_polyline_.get(),
       d_in_polyline_mask_.get(), d_in_polyline_center_.get(), stream_));
   }
+
+  // Check for NaN or invalid values in d_in_polyline_center_
+  {
+    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * 3);
+    cudaMemcpy(
+      host_buffer.data(), d_in_polyline_center_.get(),
+      num_target_ * max_num_polyline_ * 3 * sizeof(float), cudaMemcpyDeviceToHost);
+    for (const auto & val : host_buffer) {
+      if (std::isnan(val)) {
+        std::cerr << "NaN found in d_in_polyline_center_" << std::endl;
+        return false;
+      }
+    }
+  }
+
+  // Check for NaN or invalid values in d_in_polyline_
+  {
+    std::vector<float> host_buffer(num_target_ * max_num_polyline_ * num_point_ * num_point_attr_);
+    cudaMemcpy(
+      host_buffer.data(), d_in_polyline_.get(),
+      num_target_ * max_num_polyline_ * num_point_ * num_point_attr_ * sizeof(float),
+      cudaMemcpyDeviceToHost);
+    for (const auto & val : host_buffer) {
+      if (std::isnan(val)) {
+        std::cerr << "NaN found in d_in_polyline_" << std::endl;
+        return false;
+      }
+    }
+  }
+
+  // Check for NaN or invalid values in d_intention_point_
+  {
+    std::vector<float> host_buffer(num_target_ * intention_point_.size());
+    cudaMemcpy(
+      host_buffer.data(), d_intention_point_.get(),
+      num_target_ * intention_point_.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    for (const auto & val : host_buffer) {
+      if (std::isnan(val)) {
+        std::cerr << "NaN found in d_intention_point_" << std::endl;
+        return false;
+      }
+    }
+  }
   return true;
 }
 
@@ -299,40 +342,6 @@ bool TrtMTR::postProcess(
     num_target_, num_mode_, num_future_, agent_data.state_dim(), d_target_state_.get(),
     PredictedStateDim, d_out_trajectory_.get(), stream_));
 
-  // {
-  //   auto B = num_target_;
-  //   auto M = num_mode_;
-  //   auto T = num_future_;
-  //   auto D = agent_data.state_dim();
-  //   std::vector<float> host_buffer(B * M * T * D);
-
-  //   // Step 2: Copy data from GPU to host
-  //   cudaMemcpy(
-  //     host_buffer.data(), d_out_trajectory_.get(),
-  //     num_target_ * num_mode_ * num_future_ * PredictedStateDim * sizeof(float),
-  //     cudaMemcpyDeviceToHost);
-
-  //   std::cerr << "Postprocessed output \n";
-  //   std::vector<std::string> values{"x", "y", "xmean", "ymean", "std_dev", "vx", "vy"};
-  //   for (int b = 0; b < B; b++) {
-  //     for (int m = 0; m < M; m++) {
-  //       std::cerr << "{b: " << b;
-  //       std::cerr << ",m: " << m << "\n";
-  //       for (size_t d = 0; d < D; ++d) {
-  //         auto idx = b * M * T * D + m * T * D + d;
-  //         std::cerr << "idx " << idx << "\n";
-  //         auto value = host_buffer[idx];
-  //         if (std::isnan(value)) {
-  //           std::cerr << "NAN detected\n";
-  //           break;
-  //         }
-  //         std::cerr << values[d] << ": " << value << ",";
-  //       }
-
-  //       std::cerr << "}\n";
-  //     }
-  //   }
-  // }
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 
   h_out_score_.clear();


### PR DESCRIPTION
This PR adds several (possible?) fixes:

1) Sets num_targets to Target NPC + 1 (for ego)
2) Fixes the pre-process calculation, so the yaw used for calculating sine and cosine is the transformed yaw
3) Adds a small utils library to help print out data streams (for debugging only)
4) Sets cuda pointers to point to 0.0s and not random values (?)