### PR TITLE
fix: resolve invalid access to the last element of the queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ rclcpp_components_register_node(${PROJECT_NAME}_node
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_auto_add_gtest(test_fixed_queue test/test_fixed_queue.cpp)
 endif()
 
 ament_auto_package(

--- a/include/autoware/mtr/agent.hpp
+++ b/include/autoware/mtr/agent.hpp
@@ -243,7 +243,7 @@ struct AgentHistory
   bool is_valid_latest() const { return get_latest_state().is_valid(); }
 
   // Get the latest agent state at `T`.
-  const AgentState & get_latest_state() const { return *queue_.end(); }
+  const AgentState & get_latest_state() const { return queue_.back(); }
 
   // Get the latest agent state at `T`.
   std::optional<AgentState> get_latest_valid_state() const

--- a/include/autoware/mtr/fixed_queue.hpp
+++ b/include/autoware/mtr/fixed_queue.hpp
@@ -27,12 +27,14 @@ class FixedQueue
 {
 public:
   using size_type = typename std::deque<T>::size_type;
+  using reference = typename std::deque<T>::reference;
+  using const_reference = typename std::deque<T>::const_reference;
   using iterator = typename std::deque<T>::iterator;
   using riterator = typename std::reverse_iterator<iterator>;
   using const_iterator = typename std::deque<T>::const_iterator;
   using rconst_iterator = typename std::reverse_iterator<const_iterator>;
 
-  explicit FixedQueue(size_t size) { queue_.resize(size); }
+  explicit FixedQueue(size_type size) : queue_(size) {}
 
   void push_back(const T && t) noexcept
   {
@@ -57,6 +59,12 @@ public:
     queue_.pop_back();
     queue_.push_front(t);
   }
+
+  reference front() noexcept { return queue_.front(); }
+  const_reference front() const noexcept { return queue_.front(); }
+
+  reference back() noexcept { return queue_.back(); }
+  const_reference back() const noexcept { return queue_.back(); }
 
   iterator begin() noexcept { return queue_.begin(); }
   const_iterator begin() const noexcept { return queue_.begin(); }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -400,8 +400,8 @@ std::vector<float> MTRNode::getRelativeTimestamps() const
 {
   std::vector<float> output;
   output.reserve(timestamps_->size());
-  for (auto & t : *timestamps_) {
-    output.push_back(t - *timestamps_->begin());
+  for (const auto & t : *timestamps_) {
+    output.push_back(t - timestamps_->front());
   }
   return output;
 }

--- a/test/test_fixed_queue.cpp
+++ b/test/test_fixed_queue.cpp
@@ -1,0 +1,42 @@
+// Copyright 2024 TIER IV, inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/mtr/fixed_queue.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+TEST(testFixedQueue, test_name)
+{
+  constexpr size_t n_size = 5;
+  autoware::mtr::FixedQueue<double> queue(n_size);
+  EXPECT_DOUBLE_EQ(queue.front(), 0.0);
+  EXPECT_DOUBLE_EQ(queue.back(), 0.0);
+  EXPECT_EQ(queue.size(), n_size);
+
+  for (size_t n = 0; n < n_size; ++n) {
+    queue.push_back(n);
+  }
+
+  EXPECT_DOUBLE_EQ(queue.front(), 0.0);
+  EXPECT_DOUBLE_EQ(queue.back(), 4.0);
+  EXPECT_EQ(queue.size(), n_size);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What

This PR introduces member functions called `front()` and `back()` to access the first and last elements of `FixedQueue`.
Previously, we've used `*q.begin()` and `*q.end()`, but it might cause unexpected error.
Actually, in order to access the last element `*(q.end() - 1)` is correct but `*q.end()` has been used.