### PR TITLE
fix: use double instead of float to guard overflow

### DIFF
--- a/lib/src/preprocess/polyline_preprocess_kernel.cu
+++ b/lib/src/preprocess/polyline_preprocess_kernel.cu
@@ -112,8 +112,8 @@ __global__ void calculateCenterDistanceKernel(
   }
 
   // calculate polyline center
-  float sumX = 0.0f, sumY = 0.0f;
-  int numValid = 0;
+  double sumX = 0.0, sumY = 0.0;
+  double numValid = 0.0;
   for (int p = 0; p < P; ++p) {
     int idx = b * K * P + k * P + p;
     if (polylineMask[idx]) {
@@ -122,8 +122,8 @@ __global__ void calculateCenterDistanceKernel(
       ++numValid;
     }
   }
-  float centerX = sumX / fmaxf(1.0f, numValid);
-  float centerY = sumY / fmaxf(1.0f, numValid);
+  float centerX = static_cast<float>(sumX / max(1.0, numValid));
+  float centerY = static_cast<float>(sumY / max(1.0, numValid));
 
   distance[b * K + k] = hypot(centerX, centerY);
 }
@@ -198,7 +198,7 @@ __global__ void calculatePolylineCenterKernel(
 
   // calculate polyline center
   double sumX = 0.0, sumY = 0.0, sumZ = 0.0;
-  int numValid = 0;
+  double numValid = 0.0;
   for (int p = 0; p < P; ++p) {
     int idx = b * K * P + k * P + p;
     if (polylineMask[idx]) {
@@ -209,9 +209,9 @@ __global__ void calculatePolylineCenterKernel(
     }
   }
 
-  center[centerIdx] = static_cast<float>(sumX / fmaxf(1.0f, numValid));
-  center[centerIdx + 1] = static_cast<float>(sumY / fmaxf(1.0f, numValid));
-  center[centerIdx + 2] = static_cast<float>(sumZ / fmaxf(1.0f, numValid));
+  center[centerIdx] = static_cast<float>(sumX / max(1.0, numValid));
+  center[centerIdx + 1] = static_cast<float>(sumY / max(1.0, numValid));
+  center[centerIdx + 2] = static_cast<float>(sumZ / max(1.0, numValid));
 }
 
 cudaError_t polylinePreprocessWithTopkLauncher(


### PR DESCRIPTION
## What

Related to https://github.com/ktro2828/autoware_mtr/pull/28, this PR applies `double` instead of `float` to deal with overflow.