### PR TITLE
refactor: use boolean directly

### DIFF
--- a/lib/src/preprocess/agent_preprocess_kernel.cu
+++ b/lib/src/preprocess/agent_preprocess_kernel.cu
@@ -102,7 +102,7 @@ __global__ void agentPreprocessKernel(
 
   // === mask ===
   const int mask_idx = b * N * T + n * T + t;
-  out_mask[mask_idx] = is_valid == 1.0f ? true : false;
+  out_mask[mask_idx] = is_valid == 1.0f;
 
   // === last pos ===
   if (t == T - 1) {


### PR DESCRIPTION
## What

Uses `bool` directly instead of using ternary operator.